### PR TITLE
switch to relaxed sandbox

### DIFF
--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -136,7 +136,7 @@ def nix_build(attr_names: Set[str], args: str, cache_directory: Path) -> List[At
         str(multiprocessing.cpu_count()),
         "--option",
         "build-use-sandbox",
-        "true",
+        "relaxed",
         "-f",
         str(build),
     ] + shlex.split(args)

--- a/nixpkgs_review/tests/cli_mocks.py
+++ b/nixpkgs_review/tests/cli_mocks.py
@@ -85,7 +85,7 @@ build_cmds = [
             str(multiprocessing.cpu_count()),
             "--option",
             "build-use-sandbox",
-            "true",
+            "relaxed",
             "-f",
             IgnoreArgument,
             "--builders",


### PR DESCRIPTION
Since we only use disable sandboxes in nixpkgs for packages we need to,
we can just as well switch to relaxed sandboxes.

fixes #75