### PR TITLE
Add --no-shell flag for non-interactive nixpkgs-review

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ NOTE: this project used to be called `nix-review`
 - [ofborg](https://github.com/NixOS/ofborg) support: reuses evaluation output of CI to skip local evaluation, but
   also fallbacks if ofborg is not finished
 - automatically detects target branch of pull request
-- provides a `nix-shell` with all packages, that did not fail to build
+- provides a `nix-shell` with all packages that did not fail to build
 - remote builder support
 - allows to build a subset of packages (great for mass-rebuilds)
 - allow to build nixos tests
@@ -127,6 +127,39 @@ Staged changes can be reviewed like this:
 $ nixpkgs-review wip --staged
 ```
 
+## Using nix-review in scripts
+
+After building, `nixpkgs-review` will normally start a `nix-shell` with the
+packages built, to allow for interactive testing. To use `nixpkgs-review`
+non-interactively in scripts, use the `--no-shell` command, which can allow for
+batch processing of multiple reviews or use in scripts/bots.
+
+Example testing multiple unrelated PRs:
+
+```bash
+for pr in 807{60..70}; do
+    nixpkgs-review pr --no-shell $pr && echo "PR $pr succeeded" || echo "PR $pr failed"
+done
+```
+
+Example composing `nixpkgs-review` inside a script and using a token from
+[hub](https://github.com/github/hub) to post a comment on the PR with results:
+
+```
+review_pr_with_comment() {
+    nixpkgs-review pr --no-shell $1
+    escaped_msg=$(sed -e 's/"/\\"/g' ${XDG_CACHE_HOME:-${HOME}/.cache}/nixpkgs-review/pr-$1/report.md)
+    TOKEN=$(awk '/oauth_token/ {print $NF}' ~/.config/hub)
+    curl -sH "Authorization: token $TOKEN" -XPOST \
+        -d "{\"body\": \"$msg\"}" https://api.github.com/repos/NixOS/nixpkgs/issues/$1/comments
+}
+
+review_pr_with_comment 80767
+```
+
+The above is just a basic example for ideas.
+
+
 ## Remote builder:
 
 Nix-review will pass all arguments given in `--build-arg` to `nix-build`:
@@ -214,7 +247,6 @@ Note that this has been not yet implemented for pull requests i.e. `pr` subcomma
 
 ## Roadmap
 
-- [ ] trigger ofBorg builds (write @GrahamcOfBorg build foo into pull request discussion)
 - [ ] build on multiple platforms
 - [ ] test backports
 - [ ] show pull request description + diff during review

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ review_pr_with_comment() {
     escaped_msg=$(sed -e 's/"/\\"/g' ${XDG_CACHE_HOME:-${HOME}/.cache}/nixpkgs-review/pr-$1/report.md)
     TOKEN=$(awk '/oauth_token/ {print $NF}' ~/.config/hub)
     curl -sH "Authorization: token $TOKEN" -XPOST \
-        -d "{\"body\": \"$msg\"}" https://api.github.com/repos/NixOS/nixpkgs/issues/$1/comments
+        -d "{\"body\": \"$escaped_msg\"}" https://api.github.com/repos/NixOS/nixpkgs/issues/$1/comments
 }
 
 review_pr_with_comment 80767

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -138,6 +138,11 @@ def parse_args(command: str, args: List[str]) -> argparse.Namespace:
             type=regex_type,
             help="Regular expression that package attributes have to match (can be passed multiple times)",
         ),
+        CommonFlag(
+            "--no-shell",
+            action="store_true",
+            help="Only evaluate and build without executing nix-shell",
+        ),
     ]
 
     for flag in common_flags:

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -45,6 +45,7 @@ def pr_command(args: argparse.Namespace) -> None:
                 review = Review(
                     builddir=builddir,
                     build_args=args.build_args,
+                    no_shell=args.no_shell,
                     api_token=args.token,
                     use_ofborg_eval=use_ofborg_eval,
                     only_packages=set(args.package),

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -100,6 +100,10 @@ class Report:
         self.write_markdown(directory, pr)
         write_error_logs(self.attrs, directory)
 
+    def succeeded(self) -> bool:
+        """Whether the report is considered a success or a failure"""
+        return len(self.failed) == 0
+
     def write_markdown(self, directory: Path, pr: Optional[int]) -> None:
         with open(directory.joinpath("report.md"), "w+") as f:
             cmd = "nixpkgs-review"

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -79,6 +79,7 @@ class Review:
         self,
         builddir: Builddir,
         build_args: str,
+        no_shell: bool,
         api_token: Optional[str] = None,
         use_ofborg_eval: Optional[bool] = True,
         only_packages: Set[str] = set(),
@@ -87,6 +88,7 @@ class Review:
     ) -> None:
         self.builddir = builddir
         self.build_args = build_args
+        self.no_shell = no_shell
         self.github_client = GithubClient(api_token)
         self.use_ofborg_eval = use_ofborg_eval
         self.checkout = checkout
@@ -186,7 +188,10 @@ class Review:
         report = Report(attr)
         report.print_console(pr)
         report.write(self.builddir.path, pr)
-        nix_shell(report.built_packages(), self.builddir.path)
+        if self.no_shell:
+            sys.exit(0 if report.succeeded() else 1)
+        else:
+            nix_shell(report.built_packages(), self.builddir.path)
 
     def review_commit(
         self,
@@ -357,6 +362,7 @@ def review_local_revision(
         review = Review(
             builddir=builddir,
             build_args=args.build_args,
+            no_shell=args.no_shell,
             only_packages=set(args.package),
             package_regexes=args.package_regex,
         )


### PR DESCRIPTION
Add --no-shell arg for non-interactive nixpkgs-review

Usually we want to interactively review, but in some workflows we may want to
use `nixpkgs-review` to batch process a number of PR reviews.

This commit adds a `--no-shell` flag which, when passed, will do everything
except drop into the interactive `nix-shell`, and instead just finish with an
exit code signaling success or failure.

CC @jonringer @mic92