### PR TITLE
Bugfix on plural package(s) printing logic

### DIFF
--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -15,7 +15,7 @@ def print_number(
 ) -> None:
     if len(packages) == 0:
         return
-    plural = "s" if len(packages) == 0 else ""
+    plural = "s" if len(packages) > 1 else ""
     names = (a.name for a in packages)
     log(f"{len(packages)} {what}{plural} {msg}:")
     log(" ".join(names))
@@ -27,7 +27,7 @@ def write_number(
 ) -> None:
     if len(packages) == 0:
         return
-    plural = "s" if len(packages) == 0 else ""
+    plural = "s" if len(packages) > 1 else ""
     file.write(f"<details>\n")
     file.write(f"  <summary>{len(packages)} {what}{plural} {msg}:</summary>\n\n")
     for pkg in packages:

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -34,7 +34,7 @@ def native_packages(packages_per_system: Dict[str, Set[str]]) -> Set[str]:
 def print_packages(names: List[str], msg: str,) -> None:
     if len(names) == 0:
         return
-    plural = "s" if len(names) == 0 else ""
+    plural = "s" if len(names) > 1 else ""
 
     print(f"{len(names)} package{plural} {msg}:")
     print(" ".join(names))


### PR DESCRIPTION
The list of names is never 0 on this line, so we were always printing a singular
`package` here.