### PR TITLE
Refactor the report.markdown() function

### DIFF
--- a/nixpkgs_review/tests/assets/expected_pr_report_1234.md
+++ b/nixpkgs_review/tests/assets/expected_pr_report_1234.md
@@ -1,0 +1,12 @@
+Result of `nixpkgs-review pr 1234` [1](https://github.com/Mic92/nixpkgs-review)
+<details>
+  <summary>1 package failed to build:</summary>
+
+  - baz
+</details>
+<details>
+  <summary>2 packages built:</summary>
+
+  - foo
+  - bar
+</details>

--- a/nixpkgs_review/tests/test_report.py
+++ b/nixpkgs_review/tests/test_report.py
@@ -1,0 +1,39 @@
+import unittest
+
+from nixpkgs_review.report import Report
+from nixpkgs_review.nix import Attr
+
+from .cli_mocks import read_asset
+
+
+def mkAttr(name: str, success: bool) -> Attr:
+    "Helper to construct a mock Attr result for the report"
+    res = Attr(
+        name=name,
+        exists=True,
+        broken=False,
+        blacklisted=False,
+        path="some_out_path",
+        drv_path="some_drv_path",
+    )
+    res._path_verified = success
+    return res
+
+
+class ReportTestcase(unittest.TestCase):
+    def test_markdown_report(self) -> None:
+        "Test that the markdown report format is as expected"
+        foo = mkAttr("foo", True)
+        bar = mkAttr("bar", True)
+        baz = mkAttr("baz", False)
+
+        report = Report([foo, bar, baz])
+
+        expected = read_asset("expected_pr_report_1234.md")
+        actual = report.markdown(1234)
+
+        self.assertEqual(expected, actual)
+
+
+if __name__ == "__main__":
+    unittest.main(failfast=True)


### PR DESCRIPTION
This commit has no functional changes; it merely refactors the
`Report.markdown()` function to be a pure function returning a `str`, so
that we can thread it through to a `request` post in a future update as
part of #89.

Along the way, this adds test coverage to the function to help catch
refactoring bugs, issues like #88, and make the final report output format
easier to view (e.g., can just open the test file to see what it looks like
when reviewing changes to the format).