### PR TITLE
Implement --post-result function for PR review comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ redis-cli 4.0.8
 ```
 
 If you'd like to post the `nixpkgs-review` results as a formatted PR comment,
-pass the `--comment` flag:
+pass the `--post-result` flag:
 
 ```console
-$ nixpkgs-review pr --comment 37242
+$ nixpkgs-review pr --post-result 37242
 ```
 
 To review a local commit without pull request, use the following command:
@@ -147,7 +147,7 @@ comments for later review:
 
 ```bash
 for pr in 807{60..70}; do
-    nixpkgs-review pr --no-shell --comment $pr && echo "PR $pr succeeded" || echo "PR $pr failed"
+    nixpkgs-review pr --no-shell --post-result $pr && echo "PR $pr succeeded" || echo "PR $pr failed"
 done
 ```
 
@@ -165,7 +165,7 @@ This allows to parallelize builds across multiple machines.
 
 ## Github api token
 
-The `pr --comment` option requires a Github API token, and even for read-only
+The `pr --post-result` option requires a Github API token, and even for read-only
 calls github returns 403 error messages if your IP hits the rate limit for
 unauthenticated calls.
 

--- a/README.md
+++ b/README.md
@@ -165,16 +165,17 @@ This allows to parallelize builds across multiple machines.
 
 ## Github api token
 
-In case your IP exceeds the rate limit, github will return an 403 error message.
-To increase your limit first create a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/).
-Then use either the `--token` parameter of the `pr` subcommand or
-set the `GITHUB_OAUTH_TOKEN` environment variable.
+The `pr --comment` option requires a Github API token, and even for read-only
+calls github returns 403 error messages if your IP hits the rate limit for
+unauthenticated calls.
+
+To use a token, first create a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/).
+Then use either the `--token` parameter of the `pr` subcommand or set the
+`GITHUB_OAUTH_TOKEN` environment variable.
 
 ```console
 $ nixpkgs-review pr --token "5ae04810f1e9f17c3297ee4c9e25f3ac1f437c26" 37244
 ```
-
-This is required for the `pr --comment` option.
 
 ## Checkout strategy (recommend for r-ryantm + cachix)
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ NOTE: this project used to be called `nix-review`
 - allow to build nixos tests
 - colorful output
 - markdown reports
+- GitHub integration to post PR comments with results
 - logs per built or failed package
 - symlinks build packages to result directory for inspection
 
@@ -107,6 +108,13 @@ $ nix-shell -p redis
 redis-cli 4.0.8
 ```
 
+If you'd like to post the `nixpkgs-review` results as a formatted PR comment,
+pass the `--comment` flag:
+
+```console
+$ nixpkgs-review pr --comment 37242
+```
+
 To review a local commit without pull request, use the following command:
 
 ```console
@@ -134,31 +142,14 @@ packages built, to allow for interactive testing. To use `nixpkgs-review`
 non-interactively in scripts, use the `--no-shell` command, which can allow for
 batch processing of multiple reviews or use in scripts/bots.
 
-Example testing multiple unrelated PRs:
+Example testing multiple unrelated PRs and posting the build results as PR
+comments for later review:
 
 ```bash
 for pr in 807{60..70}; do
-    nixpkgs-review pr --no-shell $pr && echo "PR $pr succeeded" || echo "PR $pr failed"
+    nixpkgs-review pr --no-shell --comment $pr && echo "PR $pr succeeded" || echo "PR $pr failed"
 done
 ```
-
-Example composing `nixpkgs-review` inside a script and using a token from
-[hub](https://github.com/github/hub) to post a comment on the PR with results:
-
-```
-review_pr_with_comment() {
-    nixpkgs-review pr --no-shell $1
-    escaped_msg=$(sed -e 's/"/\\"/g' ${XDG_CACHE_HOME:-${HOME}/.cache}/nixpkgs-review/pr-$1/report.md)
-    TOKEN=$(awk '/oauth_token/ {print $NF}' ~/.config/hub)
-    curl -sH "Authorization: token $TOKEN" -XPOST \
-        -d "{\"body\": \"$escaped_msg\"}" https://api.github.com/repos/NixOS/nixpkgs/issues/$1/comments
-}
-
-review_pr_with_comment 80767
-```
-
-The above is just a basic example for ideas.
-
 
 ## Remote builder:
 
@@ -182,6 +173,8 @@ set the `GITHUB_OAUTH_TOKEN` environment variable.
 ```console
 $ nixpkgs-review pr --token "5ae04810f1e9f17c3297ee4c9e25f3ac1f437c26" 37244
 ```
+
+This is required for the `pr --comment` option.
 
 ## Checkout strategy (recommend for r-ryantm + cachix)
 

--- a/default.nix
+++ b/default.nix
@@ -1,11 +1,11 @@
 { pkgs ?  import <nixpkgs> {} }:
 
-
 with pkgs;
 python3.pkgs.buildPythonApplication rec {
   name = "nixpkgs-review";
   src = ./.;
   buildInputs = [ makeWrapper ];
+  propagatedBuildInputs = [ python3.pkgs.PyGithub ];
   checkInputs = [ mypy python3.pkgs.black python3.pkgs.flake8 glibcLocales ];
   checkPhase = ''
     echo -e "\x1b[32m## run unittest\x1b[0m"

--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,6 @@ python3.pkgs.buildPythonApplication rec {
   name = "nixpkgs-review";
   src = ./.;
   buildInputs = [ makeWrapper ];
-  propagatedBuildInputs = [ python3.pkgs.PyGithub ];
   checkInputs = [ mypy python3.pkgs.black python3.pkgs.flake8 glibcLocales ];
   checkPhase = ''
     echo -e "\x1b[32m## run unittest\x1b[0m"

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -48,6 +48,11 @@ def pr_flags(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
         nargs="+",
         help="one or more nixpkgs pull request numbers (ranges are also supported)",
     )
+    pr_parser.add_argument(
+        "--comment",
+        action="store_true",
+        help="Post the nixpkgs-review results as a PR comment",
+    )
     pr_parser.set_defaults(func=pr_command)
     return pr_parser
 

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -49,7 +49,7 @@ def pr_flags(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
         help="one or more nixpkgs pull request numbers (ranges are also supported)",
     )
     pr_parser.add_argument(
-        "--comment",
+        "--post-result",
         action="store_true",
         help="Post the nixpkgs-review results as a PR comment",
     )
@@ -160,6 +160,11 @@ def parse_args(command: str, args: List[str]) -> argparse.Namespace:
 
 def main(command: str, raw_args: List[str]) -> None:
     args = parse_args(command, raw_args)
+
+    if command == "pr" and args.post_result and not args.token:
+        raise argparse.ArgumentTypeError(
+            "Posting PR comments requires a Github API token; see https://github.com/Mic92/nixpkgs-review#github-api-token"
+        )
 
     with Buildenv():
         args.func(args)

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -161,10 +161,5 @@ def parse_args(command: str, args: List[str]) -> argparse.Namespace:
 def main(command: str, raw_args: List[str]) -> None:
     args = parse_args(command, raw_args)
 
-    if command == "pr" and args.post_result and not args.token:
-        raise argparse.ArgumentTypeError(
-            "Posting PR comments requires a Github API token; see https://github.com/Mic92/nixpkgs-review#github-api-token"
-        )
-
     with Buildenv():
         args.func(args)

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -38,7 +38,9 @@ def pr_command(args: argparse.Namespace) -> None:
     )
 
     if args.post_result and not args.token:
-        warn("Posting PR comments requires a Github API token; see https://github.com/Mic92/nixpkgs-review#github-api-token")
+        warn(
+            "Posting PR comments requires a Github API token; see https://github.com/Mic92/nixpkgs-review#github-api-token"
+        )
         sys.exit(1)
 
     contexts = []

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -2,6 +2,7 @@ import argparse
 import re
 import subprocess
 import sys
+
 from contextlib import ExitStack
 from typing import List
 
@@ -57,7 +58,7 @@ def pr_command(args: argparse.Namespace) -> None:
                 warn(f"https://github.com/NixOS/nixpkgs/pull/{pr} failed to build")
 
         for pr, attrs in contexts:
-            review.start_review(attrs, pr)
+            review.start_review(attrs, pr, args.comment)
 
         if len(contexts) != len(prs):
             sys.exit(1)

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -58,7 +58,7 @@ def pr_command(args: argparse.Namespace) -> None:
                 warn(f"https://github.com/NixOS/nixpkgs/pull/{pr} failed to build")
 
         for pr, attrs in contexts:
-            review.start_review(attrs, pr, args.comment)
+            review.start_review(attrs, pr, args.post_result)
 
         if len(contexts) != len(prs):
             sys.exit(1)

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -37,6 +37,10 @@ def pr_command(args: argparse.Namespace) -> None:
         CheckoutOption.MERGE if args.checkout == "merge" else CheckoutOption.COMMIT
     )
 
+    if args.post_result and not args.token:
+        warn("Posting PR comments requires a Github API token; see https://github.com/Mic92/nixpkgs-review#github-api-token")
+        sys.exit(1)
+
     contexts = []
 
     with ExitStack() as stack:

--- a/nixpkgs_review/github.py
+++ b/nixpkgs_review/github.py
@@ -1,7 +1,6 @@
 import json
 import urllib.parse
 import urllib.request
-import http.client
 
 from collections import defaultdict
 from typing import Any, DefaultDict, Dict, Optional, Set
@@ -35,7 +34,9 @@ class GithubClient:
 
     def issue_comment(self, pr: int, msg: str) -> Any:
         "Post a comment on a PR with nixpkgs-review report"
-        return self.post(f"/repos/NixOS/nixpkgs/issues/{pr}/comments", data=dict(body=msg))
+        return self.post(
+            f"/repos/NixOS/nixpkgs/issues/{pr}/comments", data=dict(body=msg)
+        )
 
     def pull_request(self, number: int) -> Any:
         return self.get(f"repos/NixOS/nixpkgs/pulls/{number}")

--- a/nixpkgs_review/github.py
+++ b/nixpkgs_review/github.py
@@ -1,13 +1,21 @@
-import urllib.parse
 import json
-from collections import defaultdict
+import urllib.parse
 import urllib.request
+
+from collections import defaultdict
 from typing import Any, DefaultDict, Dict, Optional, Set
+
+# The PyGithub module does have stub files, but they're not installed via its
+# setup.py, so mypy complains about missing types.
+from github import Github  # type: ignore
 
 
 class GithubClient:
     def __init__(self, api_token: Optional[str]) -> None:
         self.api_token = api_token
+        if api_token:
+            self.github = Github(api_token)
+            self.nixpkgs = self.github.get_repo("NixOS/nixpkgs")
 
     def get(self, path: str) -> Any:
         url = urllib.parse.urljoin("https://api.github.com/", path)
@@ -15,6 +23,11 @@ class GithubClient:
         if self.api_token:
             req.add_header("Authorization", f"token {self.api_token}")
         return json.loads(urllib.request.urlopen(req).read())
+
+    def pr_comment(self, pr: int, msg: str) -> None:
+        "Post a comment on a PR with nixpkgs-review report"
+        gh_pr = self.nixpkgs.get_pull(pr)
+        gh_pr.create_issue_comment(msg)
 
     def get_borg_eval_gist(self, pr: Dict[str, Any]) -> Optional[Dict[str, Set[str]]]:
         packages_per_system: DefaultDict[str, Set[str]] = defaultdict(set)

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -27,9 +27,11 @@ def html_pkgs_section(packages: List[Attr], msg: str, what: str = "package") -> 
         return ""
     plural = "s" if len(packages) > 1 else ""
     res = "<details>\n"
-    res += f"  <summary>{len(packages)} {what}{plural} {msg}:</summary>\n\n"
+    res += f"  <summary>{len(packages)} {what}{plural} {msg}:</summary>\n"
     for pkg in packages:
-        res += f"  - {pkg.name}"
+        # N.B. When posting comments via the GitHub REST API, newlines do not
+        # survive inside the HTML sections, but <br> does.
+        res += f"<br>- {pkg.name}"
         if len(pkg.aliases) > 0:
             res += f" ({' ,'.join(pkg.aliases)})"
         res += "\n"

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -184,11 +184,20 @@ class Review:
         packages = native_packages(packages_per_system)
         return self.build(packages, self.build_args)
 
-    def start_review(self, attr: List[Attr], pr: Optional[int] = None) -> None:
+    def start_review(
+        self,
+        attr: List[Attr],
+        pr: Optional[int] = None,
+        comment: Optional[bool] = False,
+    ) -> None:
         os.environ["NIX_PATH"] = self.builddir.nixpkgs_path()
         report = Report(attr)
         report.print_console(pr)
         report.write(self.builddir.path, pr)
+
+        if pr and comment:
+            self.github_client.pr_comment(pr, report.markdown(pr))
+
         if self.no_shell:
             sys.exit(0 if report.succeeded() else 1)
         else:

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -155,7 +155,8 @@ class Review:
         return nix_build(packages, args, self.builddir.path)
 
     def build_pr(self, pr_number: int) -> List[Attr]:
-        pr = self.github_client.get(f"repos/NixOS/nixpkgs/pulls/{pr_number}")
+        pr = self.github_client.pull_request(pr_number)
+
         if self.use_ofborg_eval:
             packages_per_system = self.github_client.get_borg_eval_gist(pr)
         else:
@@ -196,7 +197,7 @@ class Review:
         report.write(self.builddir.path, pr)
 
         if pr and post_result:
-            self.github_client.pr_comment(pr, report.markdown(pr))
+            res = self.github_client.issue_comment(pr, report.markdown(pr))
 
         if self.no_shell:
             sys.exit(0 if report.succeeded() else 1)

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -188,14 +188,14 @@ class Review:
         self,
         attr: List[Attr],
         pr: Optional[int] = None,
-        comment: Optional[bool] = False,
+        post_result: Optional[bool] = False,
     ) -> None:
         os.environ["NIX_PATH"] = self.builddir.nixpkgs_path()
         report = Report(attr)
         report.print_console(pr)
         report.write(self.builddir.path, pr)
 
-        if pr and comment:
+        if pr and post_result:
             self.github_client.pr_comment(pr, report.markdown(pr))
 
         if self.no_shell:

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -197,7 +197,7 @@ class Review:
         report.write(self.builddir.path, pr)
 
         if pr and post_result:
-            res = self.github_client.issue_comment(pr, report.markdown(pr))
+            self.github_client.issue_comment(pr, report.markdown(pr))
 
         if self.no_shell:
             sys.exit(0 if report.succeeded() else 1)

--- a/nixpkgs_review/tests/assets/expected_pr_report_1234.md
+++ b/nixpkgs_review/tests/assets/expected_pr_report_1234.md
@@ -1,12 +1,10 @@
 Result of `nixpkgs-review pr 1234` [1](https://github.com/Mic92/nixpkgs-review)
 <details>
   <summary>1 package failed to build:</summary>
-
-  - baz
+<br>- baz
 </details>
 <details>
   <summary>2 packages built:</summary>
-
-  - foo
-  - bar
+<br>- foo
+<br>- bar
 </details>

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
             "nixpkgs-review = nixpkgs_review:main",
         ]
     },
+    install_requires=["PyGithub"],
     extras_require={"dev": ["mypy", "flake8>=3.5,<3.6", "black"]},
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
             "nixpkgs-review = nixpkgs_review:main",
         ]
     },
-    install_requires=["PyGithub"],
     extras_require={"dev": ["mypy", "flake8>=3.5,<3.6", "black"]},
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This extends `nixpkgs-review` with a `--comment` flag, active during the `pr`
subcommand, that will post a comment on the PR review with the results.

Resolves #89

CC @mic92 @jonringer @ryantm @fridh