### PR TITLE
Implement --aprove and --merge flags for PR reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ NOTE: this project used to be called `nix-review`
 - colorful output
 - markdown reports
 - GitHub integration to post PR comments with results
+- GitHub integration to approve PRs if no builds fail
+- GitHub integration to merge PRs if no builds fail (requires NixPkgs maintainer permission)
 - logs per built or failed package
 - symlinks build packages to result directory for inspection
 
@@ -113,6 +115,20 @@ pass the `--post-result` flag:
 
 ```console
 $ nixpkgs-review pr --post-result 37242
+```
+
+Often, after reviewing a diff on a pull request, you may want to say "This diff
+looks good to me, approve/merge it provided that there are no package build
+failures". To do so:
+
+```console
+$ nixpkgs-review pr --no-shell --post-result --approve 37242
+```
+
+Or, if you have maintainer access and would like to merge (provided no build failures):
+
+```console
+$ nixpkgs-review pr --no-shell --post-result --approve --merge 37242
 ```
 
 To review a local commit without pull request, use the following command:

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -53,6 +53,14 @@ def pr_flags(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
         action="store_true",
         help="Post the nixpkgs-review results as a PR comment",
     )
+    pr_parser.add_argument(
+        "--approve",
+        action="store_true",
+        help="If there are no failures, approve the PR",
+    )
+    pr_parser.add_argument(
+        "--merge", action="store_true", help="If there are no failures, merge the PR",
+    )
     pr_parser.set_defaults(func=pr_command)
     return pr_parser
 

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -37,9 +37,9 @@ def pr_command(args: argparse.Namespace) -> None:
         CheckoutOption.MERGE if args.checkout == "merge" else CheckoutOption.COMMIT
     )
 
-    if args.post_result and not args.token:
+    if not args.token and any([args.post_result, args.approve, args.merge]):
         warn(
-            "Posting PR comments requires a Github API token; see https://github.com/Mic92/nixpkgs-review#github-api-token"
+            "Requires a Github API token; see https://github.com/Mic92/nixpkgs-review#github-api-token"
         )
         sys.exit(1)
 
@@ -64,7 +64,7 @@ def pr_command(args: argparse.Namespace) -> None:
                 warn(f"https://github.com/NixOS/nixpkgs/pull/{pr} failed to build")
 
         for pr, attrs in contexts:
-            review.start_review(attrs, pr, args.post_result)
+            review.start_review(attrs, pr, args.post_result, args.approve, args.merge)
 
         if len(contexts) != len(prs):
             sys.exit(1)

--- a/nixpkgs_review/github.py
+++ b/nixpkgs_review/github.py
@@ -32,11 +32,27 @@ class GithubClient:
     def post(self, path: str, data: Dict[str, str]) -> Any:
         return self._request(path, "POST", data)
 
+    def put(self, path: str) -> Any:
+        return self._request(path, "PUT")
+
     def issue_comment(self, pr: int, msg: str) -> Any:
         "Post a comment on a PR with nixpkgs-review report"
+        print(f"Posting result comment on PR {pr}")
         return self.post(
             f"/repos/NixOS/nixpkgs/issues/{pr}/comments", data=dict(body=msg)
         )
+
+    def pr_approve(self, pr: int) -> Any:
+        "Approve a PR"
+        print(f"Approving PR {pr}")
+        return self.post(
+            f"/repos/NixOS/nixpkgs/pulls/{pr}/reviews", data=dict(event="APPROVE"),
+        )
+
+    def pr_merge(self, pr: int) -> Any:
+        "Merge a PR. Requires maintainer access to NixPkgs"
+        print(f"Merging PR {pr}")
+        return self.put(f"/repos/NixOS/nixpkgs/pulls/{pr}/merge")
 
     def pull_request(self, number: int) -> Any:
         return self.get(f"repos/NixOS/nixpkgs/pulls/{number}")


### PR DESCRIPTION
This is intended to be used alongside --no-shell for a "post UI review"
build -> approve -> merge workflow.

The CLI and semantics here feel a little complicated. I'm not sure how to
simplify it, though; suggestions welcome.

Follow-up to #89

CC @Mic92 @jonringer @ryantm @fridh