### PR TITLE
Minor spelling correction: Ctlr-C -> Ctrl-C

### DIFF
--- a/nixpkgs_review/builddir.py
+++ b/nixpkgs_review/builddir.py
@@ -14,7 +14,7 @@ class DisableKeyboardInterrupt:
         self.signal_received = False
 
         def handler(_sig: Any, _frame: Any) -> None:
-            warn("Ignore Ctlr-C: Cleanup in progress... Don't be so impatient human!")
+            warn("Ignore Ctrl-C: Cleanup in progress... Don't be so impatient human!")
 
         self.old_handler = signal.signal(signal.SIGINT, handler)
 


### PR DESCRIPTION
I was looking at an old screenshot and noticed that this was spelt incorrectly.

![](https://cdn.discordapp.com/attachments/582281441497448510/704691712274071602/unknown.png)