### PR TITLE
Filter out meta.broken = true packages

### DIFF
--- a/nixpkgs_review/nix/evalAttrs.nix
+++ b/nixpkgs_review/nix/evalAttrs.nix
@@ -10,9 +10,10 @@ let
     attrPath = lib.splitString "." name;
     pkg = lib.attrByPath attrPath null pkgs;
     maybePath = builtins.tryEval "${pkg}";
+    markedBroken = lib.attrByPath [ "meta" "broken" ] false pkg;
   in rec {
     exists = lib.hasAttrByPath attrPath pkgs;
-    broken = !exists || !maybePath.success;
+    broken = !exists || !maybePath.success || markedBroken;
     path = if !broken then maybePath.value else null;
     drvPath = if !broken then pkg.drvPath else null;
   };


### PR DESCRIPTION
Noticed in some PRs that if a package has "meta.broken = true;" it will still be included in the "failed to build" list of packages.

Before:
```
https://github.com/NixOS/nixpkgs/pull/96432
6 packages marked as broken and skipped:
linuxPackages_hardkernel_4_14.zfs linuxPackages_hardkernel_4_14.zfsStable linuxPackages_hardkernel_4_14.zfsUnstable linuxPackages_hardkernel_latest.zfs linuxPackages_hardkernel_latest.zfsStable linuxPackages_hardkernel_latest.zfsUnstable

1 package blacklisted:
tests.nixos-functions.nixosTest-test

13 packages failed to build:
bareos deepin.dde-api deepin.dde-control-center deepin.dde-daemon deepin.dde-dock deepin.dde-file-manager deepin.dde-kwin deepin.dde-launcher deepin.dde-session-ui deepin.deepin-desktop-base deepin.deepin-desktop-schemas deepin.deepin-wallpapers deepin.startdde

87 packages built:
ceph ceph-client collectd collectd-data docker-machine-kvm docker-machine-kvm2 easysnap gnome3.gnome-boxes grub2 grub2_efi grub2_pvgrub_image grub2_xen haskellPackages.libvirt-hs haskellPackages.libzfs libceph libguestfs libguestfs-with-appliance libvirt libvirt-glib libvirt_5_9_0 libvmi linuxPackages-libre.zfs linuxPackages-libre.zfsUnstable linuxPackages.zfs linuxPackages.zfsUnstable linuxPackages_4_14.zfs linuxPackages_4_14.zfsUnstable linuxPackages_4_19.zfs linuxPackages_4_19.zfsUnstable linuxPackages_4_4.zfs linuxPackages_4_4.zfsUnstable linuxPackages_4_9.zfs linuxPackages_4_9.zfsUnstable linuxPackages_5_7.zfs linuxPackages_5_7.zfsUnstable linuxPackages_5_8.zfs linuxPackages_5_8.zfsUnstable linuxPackages_hardened.zfs linuxPackages_hardened.zfsUnstable linuxPackages_latest-libre.zfs linuxPackages_latest-libre.zfsUnstable linuxPackages_latest_hardened.zfs linuxPackages_latest_hardened.zfsUnstable linuxPackages_latest_xen_dom0.zfs linuxPackages_latest_xen_dom0.zfsUnstable linuxPackages_latest_xen_dom0_hardened.zfs linuxPackages_latest_xen_dom0_hardened.zfsUnstable linuxPackages_testing_bcachefs.zfs linuxPackages_testing_bcachefs.zfsUnstable linuxPackages_xen_dom0.zfs linuxPackages_xen_dom0.zfsUnstable linuxPackages_xen_dom0_hardened.zfs linuxPackages_xen_dom0_hardened.zfsUnstable linuxPackages_zen.zfs linuxPackages_zen.zfsUnstable minikube minishift nixops nixopsUnstable nixops_1_6_1 os-prober perl528Packages.SysVirt perl530Packages.SysVirt python27Packages.guestfs python27Packages.libvirt python37Packages.guestfs python37Packages.libvirt python38Packages.guestfs python38Packages.libvirt rubyPackages.ruby-libvirt rubyPackages_2_5.ruby-libvirt rubyPackages_2_7.ruby-libvirt sambaFull sanoid terraform-full terraform-providers.libvirt terraform_0_11-full terragrunt vagrant virt-manager virt-manager-qt virt-top virt-viewer virtlyst zfs zfsUnstable zfstools
```

After:
```
https://github.com/NixOS/nixpkgs/pull/96432
8 packages marked as broken and skipped:
bareos deepin.dde-api linuxPackages_hardkernel_4_14.zfs linuxPackages_hardkernel_4_14.zfsStable linuxPackages_hardkernel_4_14.zfsUnstable linuxPackages_hardkernel_latest.zfs linuxPackages_hardkernel_latest.zfsStable linuxPackages_hardkernel_latest.zfsUnstable

1 package blacklisted:
tests.nixos-functions.nixosTest-test

11 packages failed to build:
deepin.dde-control-center deepin.dde-daemon deepin.dde-dock deepin.dde-file-manager deepin.dde-kwin deepin.dde-launcher deepin.dde-session-ui deepin.deepin-desktop-base deepin.deepin-desktop-schemas deepin.deepin-wallpapers deepin.startdde

87 packages built:
ceph ceph-client collectd collectd-data docker-machine-kvm docker-machine-kvm2 easysnap gnome3.gnome-boxes grub2 grub2_efi grub2_pvgrub_image grub2_xen haskellPackages.libvirt-hs haskellPackages.libzfs libceph libguestfs libguestfs-with-appliance libvirt libvirt-glib libvirt_5_9_0 libvmi linuxPackages-libre.zfs linuxPackages-libre.zfsUnstable linuxPackages.zfs linuxPackages.zfsUnstable linuxPackages_4_14.zfs linuxPackages_4_14.zfsUnstable linuxPackages_4_19.zfs linuxPackages_4_19.zfsUnstable linuxPackages_4_4.zfs linuxPackages_4_4.zfsUnstable linuxPackages_4_9.zfs linuxPackages_4_9.zfsUnstable linuxPackages_5_7.zfs linuxPackages_5_7.zfsUnstable linuxPackages_5_8.zfs linuxPackages_5_8.zfsUnstable linuxPackages_hardened.zfs linuxPackages_hardened.zfsUnstable linuxPackages_latest-libre.zfs linuxPackages_latest-libre.zfsUnstable linuxPackages_latest_hardened.zfs linuxPackages_latest_hardened.zfsUnstable linuxPackages_latest_xen_dom0.zfs linuxPackages_latest_xen_dom0.zfsUnstable linuxPackages_latest_xen_dom0_hardened.zfs linuxPackages_latest_xen_dom0_hardened.zfsUnstable linuxPackages_testing_bcachefs.zfs linuxPackages_testing_bcachefs.zfsUnstable linuxPackages_xen_dom0.zfs linuxPackages_xen_dom0.zfsUnstable linuxPackages_xen_dom0_hardened.zfs linuxPackages_xen_dom0_hardened.zfsUnstable linuxPackages_zen.zfs linuxPackages_zen.zfsUnstable minikube minishift nixops nixopsUnstable nixops_1_6_1 os-prober perl528Packages.SysVirt perl530Packages.SysVirt python27Packages.guestfs python27Packages.libvirt python37Packages.guestfs python37Packages.libvirt python38Packages.guestfs python38Packages.libvirt rubyPackages.ruby-libvirt rubyPackages_2_5.ruby-libvirt rubyPackages_2_7.ruby-libvirt sambaFull sanoid terraform-full terraform-providers.libvirt terraform_0_11-full terragrunt vagrant virt-manager virt-manager-qt virt-top virt-viewer virtlyst zfs zfsUnstable zfstools
```

`bareos` and `deepin.dde-api` were moved correctly to the "marked broken" list

```
[19:07:21] jon@jon-desktop /home/jon/projects/nixpkgs (master)
$ nix-build -A bareos
error: Package ‘bareos-17.2.7’ in /home/jon/projects/nixpkgs/pkgs/tools/backup/bareos/default.nix:77 is marked as broken, refusing to evaluate.

a) For `nixos-rebuild` you can set
  { nixpkgs.config.allowBroken = true; }
in configuration.nix to override this.

b) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
  { allowBroken = true; }
to ~/.config/nixpkgs/config.nix.

(use '--show-trace' to show detailed location information)
[20:13:51] jon@jon-desktop /home/jon/projects/nixpkgs (master)
$ nix-build -A deepin.dde-api
error: Package ‘dde-api-5.0.0’ in /home/jon/projects/nixpkgs/pkgs/desktops/deepin/dde-api/default.nix:121 is marked as broken, refusing to evaluate.

a) For `nixos-rebuild` you can set
  { nixpkgs.config.allowBroken = true; }
in configuration.nix to override this.

b) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
  { allowBroken = true; }
to ~/.config/nixpkgs/config.nix.
```