### PR TITLE
fix meta check

### DIFF
--- a/nixpkgs_review/nix/evalAttrs.nix
+++ b/nixpkgs_review/nix/evalAttrs.nix
@@ -2,7 +2,7 @@ attr-json:
 
 with builtins;
 let
-  pkgs = import <nixpkgs> {};
+  pkgs = import <nixpkgs> { config = { checkMeta = true; }; };
   lib = pkgs.lib;
 
   attrs = fromJSON (readFile attr-json);
@@ -10,10 +10,9 @@ let
     attrPath = lib.splitString "." name;
     pkg = lib.attrByPath attrPath null pkgs;
     maybePath = builtins.tryEval "${pkg}";
-    markedBroken = lib.attrByPath [ "meta" "broken" ] false pkg;
   in rec {
     exists = lib.hasAttrByPath attrPath pkgs;
-    broken = !exists || !maybePath.success || markedBroken;
+    broken = !exists || !maybePath.success;
     path = if !broken then maybePath.value else null;
     drvPath = if !broken then pkg.drvPath else null;
   };


### PR DESCRIPTION
still was noticing that a lot of broken packages were still getting picked up.

I did some looking into how ofborg/hydra solve this problem. And there's explicit `checkMeta` config flag that you can pass. Apparently this is respected when building packages, but isn't respected when evaluating (unless it's passed explicitly)

before:
```
https://github.com/NixOS/nixpkgs/pull/98657
44 packages failed to build:
digikam k9copy kmymoney libsForQt5.kdewebkit libsForQt5.kreport libsForQt512.akonadi-calendar libsForQt512.akonadi-contacts libsForQt512.akonadi-import-wizard libsForQt512.akonadi-mime libsForQt512.akonadi-notes libsForQt512.akonadi-search libsForQt512.calendarsupport libsForQt512.eventviews libsForQt512.grantleetheme libsForQt512.incidenceeditor libsForQt512.kalarmcal libsForQt512.kcalutils libsForQt512.kdepim-addons libsForQt512.kdepim-apps-libs libsForQt512.kdepim-runtime libsForQt512.kidentitymanagement libsForQt512.kimap libsForQt512.kitinerary libsForQt512.kldap libsForQt512.kmail-account-wizard libsForQt512.kmailtransport libsForQt512.kmbox libsForQt512.kmime libsForQt512.kpimtextedit libsForQt512.kpkpass libsForQt512.ksmtp libsForQt512.ktnef libsForQt512.libgravatar libsForQt512.libkdepim libsForQt512.libkgapi libsForQt512.libkleo libsForQt512.libksieve libsForQt512.mailcommon libsForQt512.mailimporter libsForQt512.messagelib libsForQt512.pim-sieve-editor libsForQt512.pimcommon virtmanager-qt zanshin

231 packages built:
akonadi akregator amarok ark bomber bovo calligra dolphin dragon elisa ffmpegthumbs filelight granatier gwenview heaptrack k3b kaddressbook kalzium kapman kapptemplate kate katomic kblackbox kblocks kbounce kcachegrind kcalc kcharselect kcolorchooser kdeconnect kdenlive kdev-php kdev-python kdevelop kdevelop-unwrapped kdf kdialog kdiamond kdiff3 keditbookmarks kexi kfind kfloppy kget kgpg kgraphviewer khelpcenter kig kigo kile killbots kitinerary kleopatra klettres klines kmag kmail kmines kmix kmplot knavalbattle knetwalk knights kollision kolourpaint kompare konsole kontact konversation korganizer kpkpass krdc krename kreversi krfb kronometer krusader kshisen ksquares kstars ksystemlog kteatime ktimer ktimetracker ktorrent ktouch kturtle kwalletmanager kwave libsForQt5.akonadi-calendar libsForQt5.akonadi-contacts libsForQt5.akonadi-import-wizard libsForQt5.akonadi-mime libsForQt5.akonadi-notes libsForQt5.akonadi-search libsForQt5.baloo-widgets libsForQt5.breeze-qt5 libsForQt5.calendarsupport libsForQt5.eventviews libsForQt5.grantleetheme libsForQt5.incidenceeditor libsForQt5.kalarmcal libsForQt5.kcalutils libsForQt5.kdegraphics-mobipocket libsForQt5.kdepim-addons libsForQt5.kdepim-apps-libs libsForQt5.kdepim-runtime libsForQt5.kdiagram libsForQt5.kdoctools libsForQt5.khotkeys libsForQt5.kidentitymanagement libsForQt5.kimap libsForQt5.kipi-plugins libsForQt5.kldap libsForQt5.kmail-account-wizard libsForQt5.kmailtransport libsForQt5.kmbox libsForQt5.kmime libsForQt5.kontactinterface libsForQt5.kpimtextedit libsForQt5.kqtquickcharts libsForQt5.ksmtp libsForQt5.ktnef libsForQt5.libgravatar libsForQt5.libkcddb libsForQt5.libkdcraw libsForQt5.libkdegames libsForQt5.libkdepim libsForQt5.libkexiv2 libsForQt5.libkgapi libsForQt5.libkipi libsForQt5.libkleo libsForQt5.libkmahjongg libsForQt5.libkomparediff2 libsForQt5.libksane libsForQt5.libksieve libsForQt5.mailcommon libsForQt5.mailimporter libsForQt5.messagelib libsForQt5.pim-sieve-editor libsForQt5.pimcommon libsForQt512.baloo-widgets libsForQt512.breeze-qt5 libsForQt512.kdegraphics-mobipocket libsForQt512.kdewebkit libsForQt512.kdiagram libsForQt512.kdoctools libsForQt512.kipi-plugins libsForQt512.kontactinterface libsForQt512.kqtquickcharts libsForQt512.kreport libsForQt512.libkcddb libsForQt512.libkdcraw libsForQt512.libkdegames libsForQt512.libkexiv2 libsForQt512.libkipi libsForQt512.libkmahjongg libsForQt512.libkomparediff2 libsForQt512.libksane libsForQt514.akonadi-calendar libsForQt514.akonadi-contacts libsForQt514.akonadi-import-wizard libsForQt514.akonadi-mime libsForQt514.akonadi-notes libsForQt514.akonadi-search libsForQt514.baloo-widgets libsForQt514.breeze-qt5 libsForQt514.calendarsupport libsForQt514.eventviews libsForQt514.grantleetheme libsForQt514.incidenceeditor libsForQt514.kalarmcal libsForQt514.kcalutils libsForQt514.kdegraphics-mobipocket libsForQt514.kdepim-addons libsForQt514.kdepim-apps-libs libsForQt514.kdepim-runtime libsForQt514.kdewebkit libsForQt514.kdiagram libsForQt514.kdoctools libsForQt514.khotkeys libsForQt514.kidentitymanagement libsForQt514.kimap libsForQt514.kipi-plugins libsForQt514.kitinerary libsForQt514.kldap libsForQt514.kmail-account-wizard libsForQt514.kmailtransport libsForQt514.kmbox libsForQt514.kmime libsForQt514.kontactinterface libsForQt514.kpimtextedit libsForQt514.kpkpass libsForQt514.kqtquickcharts libsForQt514.kreport libsForQt514.ksmtp libsForQt514.ktnef libsForQt514.libgravatar libsForQt514.libkcddb libsForQt514.libkdcraw libsForQt514.libkdegames libsForQt514.libkdepim libsForQt514.libkexiv2 libsForQt514.libkgapi libsForQt514.libkipi libsForQt514.libkleo libsForQt514.libkmahjongg libsForQt514.libkomparediff2 libsForQt514.libksane libsForQt514.libksieve libsForQt514.mailcommon libsForQt514.mailimporter libsForQt514.messagelib libsForQt514.pim-sieve-editor libsForQt514.pimcommon marble massif-visualizer minuet okteta okular partition-manager peruse picmi rsibreak skanlite skrooge soundkonverter spectacle tellico trojita yakuake
```

after:
```
https://github.com/NixOS/nixpkgs/pull/98657
70 packages marked as broken and skipped:
akonadi akregator calligra elisa k9copy kaddressbook kgpg kitinerary kleopatra kmail kmymoney kontact korganizer kpkpass kwave libsForQt5.akonadi-calendar libsForQt5.akonadi-contacts libsForQt5.akonadi-import-wizard libsForQt5.akonadi-mime libsForQt5.akonadi-notes libsForQt5.akonadi-search libsForQt5.baloo-widgets libsForQt5.breeze-qt5 libsForQt5.calendarsupport libsForQt5.eventviews libsForQt5.grantleetheme libsForQt5.incidenceeditor libsForQt5.kalarmcal libsForQt5.kcalutils libsForQt5.kdegraphics-mobipocket libsForQt5.kdepim-addons libsForQt5.kdepim-apps-libs libsForQt5.kdepim-runtime libsForQt5.kdewebkit libsForQt5.khotkeys libsForQt5.kidentitymanagement libsForQt5.kimap libsForQt5.kipi-plugins libsForQt5.kitinerary libsForQt5.kldap libsForQt5.kmail-account-wizard libsForQt5.kmailtransport libsForQt5.kmbox libsForQt5.kmime libsForQt5.kontactinterface libsForQt5.kpimtextedit libsForQt5.kpkpass libsForQt5.kqtquickcharts libsForQt5.kreport libsForQt5.ksmtp libsForQt5.ktnef libsForQt5.libgravatar libsForQt5.libkcddb libsForQt5.libkdcraw libsForQt5.libkdegames libsForQt5.libkdepim libsForQt5.libkexiv2 libsForQt5.libkgapi libsForQt5.libkipi libsForQt5.libkleo libsForQt5.libkmahjongg libsForQt5.libkomparediff2 libsForQt5.libksane libsForQt5.libksieve libsForQt5.mailcommon libsForQt5.mailimporter libsForQt5.messagelib libsForQt5.pim-sieve-editor libsForQt5.pimcommon minuet

40 packages failed to build:
digikam libsForQt512.akonadi-calendar libsForQt512.akonadi-contacts libsForQt512.akonadi-import-wizard libsForQt512.akonadi-mime libsForQt512.akonadi-notes libsForQt512.akonadi-search libsForQt512.calendarsupport libsForQt512.eventviews libsForQt512.grantleetheme libsForQt512.incidenceeditor libsForQt512.kalarmcal libsForQt512.kcalutils libsForQt512.kdepim-addons libsForQt512.kdepim-apps-libs libsForQt512.kdepim-runtime libsForQt512.kidentitymanagement libsForQt512.kimap libsForQt512.kitinerary libsForQt512.kldap libsForQt512.kmail-account-wizard libsForQt512.kmailtransport libsForQt512.kmbox libsForQt512.kmime libsForQt512.kpimtextedit libsForQt512.kpkpass libsForQt512.ksmtp libsForQt512.ktnef libsForQt512.libgravatar libsForQt512.libkdepim libsForQt512.libkgapi libsForQt512.libkleo libsForQt512.libksieve libsForQt512.mailcommon libsForQt512.mailimporter libsForQt512.messagelib libsForQt512.pim-sieve-editor libsForQt512.pimcommon virtmanager-qt zanshin

165 packages built:
amarok ark bomber bovo dolphin ffmpegthumbs filelight granatier gwenview heaptrack k3b kalzium kapman kapptemplate kate katomic kblackbox kblocks kbounce kcachegrind kcalc kcharselect kcolorchooser kdeconnect kdev-php kdev-python kdevelop kdevelop-unwrapped kdf kdialog kdiamond kdiff3 keditbookmarks kexi kfind kfloppy kget kgraphviewer khelpcenter kig kigo kile killbots klettres klines kmag kmines kmix kmplot knavalbattle knetwalk knights kollision kolourpaint kompare konsole konversation krdc krename kreversi krfb kronometer krusader kshisen ksquares kstars ksystemlog kteatime ktimer ktimetracker ktorrent ktouch kturtle kwalletmanager libsForQt5.kdiagram libsForQt5.kdoctools libsForQt512.baloo-widgets libsForQt512.breeze-qt5 libsForQt512.kdegraphics-mobipocket libsForQt512.kdewebkit libsForQt512.kdiagram libsForQt512.kdoctools libsForQt512.kipi-plugins libsForQt512.kontactinterface libsForQt512.kqtquickcharts libsForQt512.kreport libsForQt512.libkcddb libsForQt512.libkdcraw libsForQt512.libkdegames libsForQt512.libkexiv2 libsForQt512.libkipi libsForQt512.libkmahjongg libsForQt512.libkomparediff2 libsForQt512.libksane libsForQt514.akonadi-calendar libsForQt514.akonadi-contacts libsForQt514.akonadi-import-wizard libsForQt514.akonadi-mime libsForQt514.akonadi-notes libsForQt514.akonadi-search libsForQt514.baloo-widgets libsForQt514.breeze-qt5 libsForQt514.calendarsupport libsForQt514.eventviews libsForQt514.grantleetheme libsForQt514.incidenceeditor libsForQt514.kalarmcal libsForQt514.kcalutils libsForQt514.kdegraphics-mobipocket libsForQt514.kdepim-addons libsForQt514.kdepim-apps-libs libsForQt514.kdepim-runtime libsForQt514.kdewebkit libsForQt514.kdiagram libsForQt514.kdoctools libsForQt514.khotkeys libsForQt514.kidentitymanagement libsForQt514.kimap libsForQt514.kipi-plugins libsForQt514.kitinerary libsForQt514.kldap libsForQt514.kmail-account-wizard libsForQt514.kmailtransport libsForQt514.kmbox libsForQt514.kmime libsForQt514.kontactinterface libsForQt514.kpimtextedit libsForQt514.kpkpass libsForQt514.kqtquickcharts libsForQt514.kreport libsForQt514.ksmtp libsForQt514.ktnef libsForQt514.libgravatar libsForQt514.libkcddb libsForQt514.libkdcraw libsForQt514.libkdegames libsForQt514.libkdepim libsForQt514.libkexiv2 libsForQt514.libkgapi libsForQt514.libkipi libsForQt514.libkleo libsForQt514.libkmahjongg libsForQt514.libkomparediff2 libsForQt514.libksane libsForQt514.libksieve libsForQt514.mailcommon libsForQt514.mailimporter libsForQt514.messagelib libsForQt514.pim-sieve-editor libsForQt514.pimcommon marble massif-visualizer okteta okular partition-manager peruse picmi rsibreak skanlite skrooge soundkonverter spectacle tellico trojita yakuake
```