### PR TITLE
Allow for unfree packages to be built

### DIFF
--- a/nixpkgs_review/nix/evalAttrs.nix
+++ b/nixpkgs_review/nix/evalAttrs.nix
@@ -2,7 +2,7 @@ attr-json:
 
 with builtins;
 let
-  pkgs = import <nixpkgs> { config = { checkMeta = true; }; };
+  pkgs = import <nixpkgs> { config = { checkMeta = true; allowUnfree = true; }; };
   lib = pkgs.lib;
 
   attrs = fromJSON (readFile attr-json);


### PR DESCRIPTION
This allows for unfree packages to not be marked as "broken or skipped"

closes #134


without changes:
```
[11:30:54] jon@jon-desktop /home/jon/projects/nixpkgs (fix-tabnine)
$ ../nix-review/result/bin/nixpkgs-review pr 99310
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0 pull/99310/head:refs/nixpkgs-review/1
$ git worktree add /home/jon/.cache/nixpkgs-review/pr-99310-5/nixpkgs ebb5b9ab2e38afb58abd4723a407b39198675754
Preparing worktree (detached HEAD ebb5b9ab2e3)
HEAD is now at ebb5b9ab2e3 Merge pull request #99282 from fadenb/systemdjournal2gelf_20200813
$ nix-env -f /home/jon/.cache/nixpkgs-review/pr-99310-5/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit 211f37819c143d6260d0fba61bfe6ae8863dea51
Updating ebb5b9ab2e3..211f37819c1
Fast-forward
 pkgs/development/tools/tabnine/default.nix | 10 +++++-----
 1 file changed, 5 insertions(+), 5 deletions(-)
$ nix-env -f /home/jon/.cache/nixpkgs-review/pr-99310-5/nixpkgs -qaP --xml --out-path --show-trace --meta
2 packages updated:
tabnine vimplugin-completion-tabnine

https://github.com/NixOS/nixpkgs/pull/99310
2 packages marked as broken and skipped:
tabnine vimPlugins.completion-tabnine

$ nix-shell /home/jon/.cache/nixpkgs-review/pr-99310-5/shell.nix

[nix-shell:/home/jon/.cache/nixpkgs-review/pr-99310-5]$
```

with changes:
```
[11:28:34] jon@jon-desktop /home/jon/projects/nixpkgs (fix-tabnine)
$ ../nix-review/result/bin/nixpkgs-review pr --allow-unfree 99310
$ git -c fetch.prune=false fetch --force https://github.com/NixOS/nixpkgs master:refs/nixpkgs-review/0 pull/99310/head:refs/nixpkgs-review/1
$ git worktree add /home/jon/.cache/nixpkgs-review/pr-99310-4/nixpkgs ebb5b9ab2e38afb58abd4723a407b39198675754
Preparing worktree (detached HEAD ebb5b9ab2e3)
HEAD is now at ebb5b9ab2e3 Merge pull request #99282 from fadenb/systemdjournal2gelf_20200813
$ nix-env -f /home/jon/.cache/nixpkgs-review/pr-99310-4/nixpkgs -qaP --xml --out-path --show-trace
$ git merge --no-commit 211f37819c143d6260d0fba61bfe6ae8863dea51
Updating ebb5b9ab2e3..211f37819c1
Fast-forward
 pkgs/development/tools/tabnine/default.nix | 10 +++++-----
 1 file changed, 5 insertions(+), 5 deletions(-)
$ nix-env -f /home/jon/.cache/nixpkgs-review/pr-99310-4/nixpkgs -qaP --xml --out-path --show-trace --meta
2 packages updated:
tabnine vimplugin-completion-tabnine

$ nix build --no-link --keep-going --option build-use-sandbox relaxed -f /home/jon/.cache/nixpkgs-review/pr-99310-4/build.nix
[3 built, 3 copied (0.1 MiB), 0.0 MiB DL]
https://github.com/NixOS/nixpkgs/pull/99310
2 packages built:
tabnine vimPlugins.completion-tabnine

$ nix-shell /home/jon/.cache/nixpkgs-review/pr-99310-4/shell.nix

[nix-shell:/home/jon/.cache/nixpkgs-review/pr-99310-4]$
```