### PR TITLE
Make the PR link distinct and clickable

### DIFF
--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -126,7 +126,7 @@ class Report:
     def print_console(self, pr: Optional[int]) -> None:
         if pr is not None:
             pr_url = f"https://github.com/NixOS/nixpkgs/pull/{pr}"
-            info(f"\nLink to currently reviewing PR:")
+            info("\nLink to currently reviewing PR:")
             link(f"\u001b]8;;{pr_url}\u001b\\{pr_url}\u001b]8;;\u001b\\\n")
         print_number(self.broken, "marked as broken and skipped")
         print_number(

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Callable, List, Optional
 
 from .nix import Attr
-from .utils import info, warn
+from .utils import info, link, warn
 
 
 def print_number(
@@ -125,7 +125,9 @@ class Report:
 
     def print_console(self, pr: Optional[int]) -> None:
         if pr is not None:
-            info(f"https://github.com/NixOS/nixpkgs/pull/{pr}")
+            pr_url = f"https://github.com/NixOS/nixpkgs/pull/{pr}"
+            info(f"\nLink to currently reviewing PR:")
+            link(f"\u001b]8;;{pr_url}\u001b\\{pr_url}\u001b]8;;\u001b\\\n")
         print_number(self.broken, "marked as broken and skipped")
         print_number(
             self.non_existant,

--- a/nixpkgs_review/utils.py
+++ b/nixpkgs_review/utils.py
@@ -20,6 +20,7 @@ def color_text(code: int, file: IO[Any] = sys.stdout) -> Callable[[str], None]:
 
 warn = color_text(31, file=sys.stderr)
 info = color_text(32)
+link = color_text(34)
 
 
 def sh(


### PR DESCRIPTION
I always had trouble finding the link to the currently running review. So I made it blue, clickable and added some whitespace.

![image](https://user-images.githubusercontent.com/7258858/97712953-70e40700-1abf-11eb-9c57-33f1bbb4b350.png)

Compared to 
![image](https://user-images.githubusercontent.com/7258858/97713011-8822f480-1abf-11eb-80d2-767a05cfeab2.png) I can now easily find the link.

