### PR TITLE
Fix stackoverflow

### DIFF
--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -281,6 +281,8 @@ def parse_packages_xml(stdout: IO[bytes]) -> List[Package]:
                 description = value
             elif name == "position":
                 position = value
+        elif event == "end":
+            elem.clear()
     return packages
 
 


### PR DESCRIPTION
Before this if parsing very large amounts of xml I got:

```
error: stack overflow (possible infinite recursion)
```

This happened when reviewing merge PRs which trigger no merge conflict which can happen quite often when reviewing a lot of PRs.