### PR TITLE
Add --system argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,11 +327,21 @@ overwrite the upstream repository URL (defaults to
 `https://github.com/NixOS/nixpkgs`). The following example will use the
 `mayflower` nixpkg's fork to fetch the branch where the changes will be merged into:
 
-```
-nixpkgs-review --remote https://github.com/mayflower/nixpkgs wip
+```console
+$ nixpkgs-review --remote https://github.com/mayflower/nixpkgs wip
 ```
 
 Note that this has been not yet implemented for pull requests i.e. `pr` subcommand.
+
+## Review changes for other operating systems/architectures
+
+The `--system` flag allows to set a system different from the current one.
+Note that the result nix-shell may not be able to execute all hooks correctly
+since the architecture/operating system mismatches.
+
+```console
+$ nixpkgs-review --system aarch64-linux pr 98734
+```
 
 ## Roadmap
 

--- a/default.nix
+++ b/default.nix
@@ -14,6 +14,7 @@ python3.pkgs.buildPythonApplication rec {
     # needed for interactive unittests
     python3.pkgs.pytest
     nixFlakes
+    git
   ];
 
   checkPhase = ''

--- a/flake.lock
+++ b/flake.lock
@@ -19,9 +19,10 @@
       "locked": {
         "lastModified": 1613848021,
         "narHash": "sha256-9JICogf6yTscjE3bmeX13vks+omv8408I3B7gWIau5U=",
-        "path": "/nix/store/z87z2f1vf6wzjl9nh1rs7k1ki9s6yf2k-source",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
         "rev": "1c5ca28030c459fc10d69b8608c66ed3a45f8fe9",
-        "type": "path"
+        "type": "github"
       },
       "original": {
         "id": "nixpkgs",

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -186,6 +186,11 @@ def common_flags() -> List[CommonFlag]:
             help="Name of the nixpkgs repo to review",
         ),
         CommonFlag(
+            "--system",
+            type=str,
+            help="Nix 'system' to evaluate and build packages for",
+        ),
+        CommonFlag(
             "--pkgs",
             default=None,
             type=str,

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -60,6 +60,7 @@ def pr_command(args: argparse.Namespace) -> str:
                     package_regexes=args.package_regex,
                     skip_packages=set(args.skip_package),
                     skip_packages_regex=args.skip_package_regex,
+                    system=args.system,
                     checkout=checkout_option,
                 )
                 contexts.append((pr, builddir.path, review.build_pr(pr)))

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -42,11 +42,12 @@ class Attr:
 def nix_shell(
     attrs: List[str],
     cache_directory: Path,
+    system: str,
     pkgs: Optional[str],
     run: Optional[str] = None,
 ) -> None:
     shell = cache_directory.joinpath("shell.nix")
-    write_shell_expression(shell, attrs, pkgs)
+    write_shell_expression(shell, attrs, system, pkgs)
     args = ["nix-shell", str(shell)]
     if run:
         args.extend(["--run", run])
@@ -89,7 +90,7 @@ def _nix_eval_filter(json: Dict[str, Any]) -> List[Attr]:
     return list(attr_by_path.values()) + broken
 
 
-def nix_eval(attrs: Set[str]) -> List[Attr]:
+def nix_eval(attrs: Set[str], system: str) -> List[Attr]:
     attr_json = NamedTemporaryFile(mode="w+", delete=False)
     delete = True
     try:
@@ -100,6 +101,8 @@ def nix_eval(attrs: Set[str]) -> List[Attr]:
             "nix",
             "--experimental-features",
             "nix-command",
+            "--system",
+            system,
             "eval",
             "--json",
             "--impure",
@@ -126,13 +129,17 @@ def nix_eval(attrs: Set[str]) -> List[Attr]:
 
 
 def nix_build(
-    attr_names: Set[str], args: str, cache_directory: Path, pkgs: Optional[str]
+    attr_names: Set[str],
+    args: str,
+    cache_directory: Path,
+    system: str,
+    pkgs: Optional[str],
 ) -> List[Attr]:
     if not attr_names:
         info("Nothing to be built.")
         return []
 
-    attrs = nix_eval(attr_names)
+    attrs = nix_eval(attr_names, system)
     filtered = []
     for attr in attrs:
         if not (attr.broken or attr.blacklisted):
@@ -142,7 +149,7 @@ def nix_build(
         return attrs
 
     build = cache_directory.joinpath("build.nix")
-    write_shell_expression(build, filtered, pkgs)
+    write_shell_expression(build, filtered, system, pkgs)
 
     command = [
         "nix",
@@ -174,14 +181,14 @@ def nix_build(
 
 
 def write_shell_expression(
-    filename: Path, attrs: List[str], pkgs: Optional[str]
+    filename: Path, attrs: List[str], system: str, pkgs: Optional[str]
 ) -> None:
     if pkgs:
         pkgs = f".{pkgs}"
 
     with open(filename, "w+") as f:
         f.write(
-            f"""{{ pkgs ? import ./nixpkgs {{}} }}:
+            f"""{{ pkgs ? import ./nixpkgs {{ system = \"{system}\"; }} }}:
 with pkgs{pkgs or ""};
 let
   paths = [

--- a/tests/assets/nixpkgs/default.nix
+++ b/tests/assets/nixpkgs/default.nix
@@ -1,8 +1,8 @@
-{ config ? {} }:
+{ config ? {}, system ? null } @ args:
 let
-  pkgs = import @NIXPKGS@ {
+  pkgs = import @NIXPKGS@ (args // {
     inherit config;
-  };
+  });
 in {
   pkg1 = pkgs.stdenv.mkDerivation {
     name = "pkg1";


### PR DESCRIPTION
Add a `--system` argument, which can be used to evaluate and build packages for systems other than the local one.

It passes down the specified system to nix invocations when evaluating the package set as the `system` option. During evaluation it should not matter if the local nix can actually build packages for the system, as it primarily sets `builtins.currentSystem`. I'm not sure if this is also true for IFD evaluations.

When constructing the nix-shell with the packages to build, it sets the `nixpkgs { system = ...; }` config. This avoids miss-configuring the build environment with a system that can't actually be build locally and allows to use all the configured nix build systems.