### PR TITLE
Override --ff-only option which might be globally configured

### DIFF
--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -123,7 +123,7 @@ class Review:
         return str(self.builddir.worktree_dir)
 
     def git_merge(self, commit: str) -> None:
-        sh(["git", "merge", "--no-commit", commit], cwd=self.worktree_dir())
+        sh(["git", "merge", "--no-commit", "--no-ff", commit], cwd=self.worktree_dir())
 
     def apply_unstaged(self, staged: bool = False) -> None:
         args = ["git", "--no-pager", "diff"]

--- a/nixpkgs_review/tests/test_pr_borg_eval.py
+++ b/nixpkgs_review/tests/test_pr_borg_eval.py
@@ -47,7 +47,7 @@ def borg_eval_cmds() -> List[Tuple[Any, Any]]:
             MockCompletedProcess(stdout="hash2\n"),
         ),
         (["git", "worktree", "add", IgnoreArgument, "hash1"], MockCompletedProcess()),
-        (["git", "merge", "--no-commit", "hash2"], MockCompletedProcess()),
+        (["git", "merge", "--no-commit", "--no-ff", "hash2"], MockCompletedProcess()),
         (
             [
                 "nix",

--- a/nixpkgs_review/tests/test_pr_local_eval.py
+++ b/nixpkgs_review/tests/test_pr_local_eval.py
@@ -45,7 +45,7 @@ def local_eval_cmds() -> List[Tuple[Any, Any]]:
         ),
         (["git", "worktree", "add", IgnoreArgument, "hash1"], 0),
         (IgnoreArgument, MockCompletedProcess(stdout=StringIO("<items></items>"))),
-        (["git", "merge", "--no-commit", "hash2"], MockCompletedProcess()),
+        (["git", "merge", "--no-commit", "--ff-only", "hash2"], MockCompletedProcess()),
         (
             IgnoreArgument,
             MockCompletedProcess(stdout=StringIO(read_asset("package_list_after.txt"))),

--- a/nixpkgs_review/tests/test_pr_local_eval.py
+++ b/nixpkgs_review/tests/test_pr_local_eval.py
@@ -45,7 +45,7 @@ def local_eval_cmds() -> List[Tuple[Any, Any]]:
         ),
         (["git", "worktree", "add", IgnoreArgument, "hash1"], 0),
         (IgnoreArgument, MockCompletedProcess(stdout=StringIO("<items></items>"))),
-        (["git", "merge", "--no-commit", "--ff-only", "hash2"], MockCompletedProcess()),
+        (["git", "merge", "--no-commit", "--no-ff", "hash2"], MockCompletedProcess()),
         (
             IgnoreArgument,
             MockCompletedProcess(stdout=StringIO(read_asset("package_list_after.txt"))),

--- a/nixpkgs_review/tests/test_rev.py
+++ b/nixpkgs_review/tests/test_rev.py
@@ -39,7 +39,7 @@ def rev_command_cmds() -> List[Tuple[Any, Any]]:
         ),
         (["git", "worktree", "add", IgnoreArgument, "hash1"], MockCompletedProcess()),
         (IgnoreArgument, MockCompletedProcess(stdout=StringIO("<items></items>"))),
-        (["git", "merge", "--no-commit", "hash1"], MockCompletedProcess()),
+        (["git", "merge", "--no-commit", "--ff-only", "hash1"], MockCompletedProcess()),
         (
             IgnoreArgument,
             MockCompletedProcess(stdout=StringIO(read_asset("package_list_after.txt"))),

--- a/nixpkgs_review/tests/test_rev.py
+++ b/nixpkgs_review/tests/test_rev.py
@@ -39,7 +39,7 @@ def rev_command_cmds() -> List[Tuple[Any, Any]]:
         ),
         (["git", "worktree", "add", IgnoreArgument, "hash1"], MockCompletedProcess()),
         (IgnoreArgument, MockCompletedProcess(stdout=StringIO("<items></items>"))),
-        (["git", "merge", "--no-commit", "--ff-only", "hash1"], MockCompletedProcess()),
+        (["git", "merge", "--no-commit", "--no-ff", "hash1"], MockCompletedProcess()),
         (
             IgnoreArgument,
             MockCompletedProcess(stdout=StringIO(read_asset("package_list_after.txt"))),


### PR DESCRIPTION
This fixes the problem with "Not possible to fast-forward..."
in environments where git is configured with `ff = only`

## To reproduce

configure git with `ff only`:

```
$ git config merge.ff only
```

And try to run nix-review in cases where fast forward is not an option.

## Workaround

If you have this in global configuration at the moment the easiest way is to reconfigure nixpkgs repository to override this:

```
$ git config merge.ff false
```

This patch should make it so that merge nixpkgs-review is doing is independent of a configuration.