### PR TITLE
Blacklist tests.writers

### DIFF
--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -51,6 +51,7 @@ def _nix_eval_filter(json: Dict[str, Any]) -> List[Attr]:
         [
             "tests.nixos-functions.nixos-test",
             "tests.nixos-functions.nixosTest-test",
+            "tests.writers",
             "appimage-run-tests",
         ]
     )


### PR DESCRIPTION
While doing ``nixpkgs-review pr 110813`` I got the following error:

```
The store path /nix/store/4q77nsvmv3gg80bg0r43d5m9aiifdxhf-test-writers is a file and can't be merged into an environment using pkgs.buildEnv! at /nix/store/pm3r9b13iwvw2hr7v7b9nwlnssp0i858-builder.pl line 109.
The store path /nix/store/4q77nsvmv3gg80bg0r43d5m9aiifdxhf-test-writers is a file and can't be merged into an environment using pkgs.buildEnv! at /nix/store/pm3r9b13iwvw2hr7v7b9nwlnssp0i858-builder.pl line 109.
builder for '/nix/store/3hp03ih3grhpb1s2cg5gq1bgghwpa2m0-env.drv' failed with exit code 2
error: --- Error ----------------------------------------------------------------------------------------------------------------------------------------------------------------- nix-shellbuild of '/nix/store/3hp03ih3grhpb1s2cg5gq1bgghwpa2m0-env.drv' failed 
```