### PR TITLE
Fix log collection for already build packages

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -28,7 +28,7 @@ python3.pkgs.buildPythonApplication rec {
     mypy --strict nixpkgs_review
   '';
   makeWrapperArgs = [
-    "--prefix PATH : ${stdenv.lib.makeBinPath [ nixFlakes git ]}"
+    "--prefix PATH : ${lib.makeBinPath [ nixFlakes git ]}"
     "--set NIX_SSL_CERT_FILE ${cacert}/etc/ssl/certs/ca-bundle.crt"
     # we don't have any runtime deps but nix-review shells might inject unwanted dependencies
     "--unset PYTHONPATH"

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -63,7 +63,7 @@ def write_error_logs(attrs: List[Attr], directory: Path) -> None:
                 symlink_source.unlink()
             symlink_source.symlink_to(attr.path)
 
-        if attr.drv_path is not None:
+        if attr.path is not None:
             with open(logs.ensure().joinpath(attr.name + ".log"), "w+") as f:
                 subprocess.run(
                     [
@@ -71,7 +71,7 @@ def write_error_logs(attrs: List[Attr], directory: Path) -> None:
                         "--experimental-features",
                         "nix-command",
                         "log",
-                        attr.drv_path,
+                        attr.path,
                     ],
                     stdout=f,
                 )


### PR DESCRIPTION
- Fix log files not being collected for already build packages
- Remove usage of stdenv.lib

Before nix log used the drv to collect the log files which are not available after a rebuild.

```
error: --- Error -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
nixbuild log of '/nix/store/g3328kr658gkvc2230dv6ay7gw6ac94j-perl5.32.0-wakeonlan-0.41.drv' is not available
```

Now we just use the path of the build package where we can always collect the log.

I require this to grep logs when doing more than one run of nixpkgs-reviews.
