### PR TITLE
Unset NIXPKGS_CONFIG to respect meta.broken in review shells

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -26,7 +26,7 @@ python3.pkgs.buildPythonApplication rec {
     echo -e "\x1b[32m## run flake8\x1b[0m"
     flake8 .
     echo -e "\x1b[32m## run mypy\x1b[0m"
-    mypy --strict .
+    mypy --strict nixpkgs_review
   '';
   makeWrapperArgs = [
     "--prefix PATH : ${lib.makeBinPath [ nixFlakes git ]}"

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -228,6 +228,7 @@ class Review:
         pr: Optional[int] = None,
         post_result: Optional[bool] = False,
     ) -> None:
+        os.environ.pop("NIXPKGS_CONFIG", None)
         os.environ["NIX_PATH"] = path.as_posix()
         if pr:
             os.environ["PR"] = str(pr)


### PR DESCRIPTION
As discussed in IRC and the meetup. This change respects meta.broken in review-shells.