### PR TITLE
Don't use aliases when evalling locally

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,7 +13,7 @@ python3.pkgs.buildPythonApplication rec {
 
     # needed for interactive unittests
     python3.pkgs.pytest
-    nixFlakes
+    nixUnstable
     git
   ];
 
@@ -30,7 +30,7 @@ python3.pkgs.buildPythonApplication rec {
     mypy --strict nixpkgs_review
   '';
   makeWrapperArgs = [
-    "--prefix PATH : ${lib.makeBinPath [ nixFlakes git ]}"
+    "--prefix PATH : ${lib.makeBinPath [ nixUnstable git ]}"
     "--set NIX_SSL_CERT_FILE ${cacert}/etc/ssl/certs/ca-bundle.crt"
     # we don't have any runtime deps but nix-review shells might inject unwanted dependencies
     "--unset PYTHONPATH"

--- a/nixpkgs_review/builddir.py
+++ b/nixpkgs_review/builddir.py
@@ -54,11 +54,10 @@ class Builddir:
         else:
             self.path = self.directory
 
-        self.worktree_dir = self.path.joinpath("nixpkgs")
         self.overlay = Overlay()
 
+        self.worktree_dir = self.path.joinpath("nixpkgs")
         self.worktree_dir.mkdir()
-
         self.worktree_dir = self.worktree_dir
 
         os.environ["NIX_PATH"] = self.nixpkgs_path()

--- a/nixpkgs_review/buildenv.py
+++ b/nixpkgs_review/buildenv.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import sys
 from tempfile import NamedTemporaryFile
@@ -20,6 +21,9 @@ def find_nixpkgs_root() -> Optional[str]:
 
 
 class Buildenv:
+    def __init__(self, args: argparse.Namespace):
+        self.args = args
+
     def __enter__(self) -> None:
         self.environ = os.environ.copy()
         self.old_cwd = os.getcwd()
@@ -38,12 +42,15 @@ class Buildenv:
 
         self.nixpkgs_config = NamedTemporaryFile()
         self.nixpkgs_config.write(
-            b"""{
+            str.encode(
+                f"""{{
           allowUnfree = true;
           allowBroken = true;
+          {"allowAliases = false;" if self.args.allow_aliases else ""}
           ## TODO also build packages marked as insecure
           #allowInsecurePredicate = x: true;
-        } """
+        }}"""
+            )
         )
         self.nixpkgs_config.flush()
         os.environ["NIXPKGS_CONFIG"] = self.nixpkgs_config.name

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -132,6 +132,12 @@ def read_github_token() -> Optional[str]:
 def common_flags() -> List[CommonFlag]:
     return [
         CommonFlag(
+            "--disable-aliases",
+            dest="allow_aliases",
+            action="store_false",
+            help="Disable aliases while evaluating locally. They are automatically disabled when reviewing NixOS/nixpkgs PRs against master.",
+        ),
+        CommonFlag(
             "--build-args", default="", help="arguments passed to nix when building"
         ),
         CommonFlag(

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -135,6 +135,11 @@ def common_flags() -> List[CommonFlag]:
             "--build-args", default="", help="arguments passed to nix when building"
         ),
         CommonFlag(
+            "--no-shell",
+            action="store_true",
+            help="Only evaluate and build without executing nix-shell",
+        ),
+        CommonFlag(
             "-p",
             "--package",
             action="append",
@@ -147,6 +152,18 @@ def common_flags() -> List[CommonFlag]:
             default=[],
             type=regex_type,
             help="Regular expression that package attributes have to match (can be passed multiple times)",
+        ),
+        CommonFlag(
+            "-r",
+            "--remote",
+            default="https://github.com/NixOS/nixpkgs",
+            help="Name of the nixpkgs repo to review",
+        ),
+        CommonFlag(
+            "--run",
+            type=str,
+            default="",
+            help="Passed to nix-shell to run a command instead of an interactive nix-shell",
         ),
         CommonFlag(
             "-P",
@@ -163,32 +180,15 @@ def common_flags() -> List[CommonFlag]:
             help="Regular expression that package attributes have not to match (can be passed multiple times)",
         ),
         CommonFlag(
-            "--no-shell",
-            action="store_true",
-            help="Only evaluate and build without executing nix-shell",
-        ),
-        CommonFlag(
-            "--run",
+            "--system",
             type=str,
-            default="",
-            help="Passed to nix-shell to run a command instead of an interactive nix-shell",
+            help="Nix 'system' to evaluate and build packages for",
         ),
         CommonFlag(
             "--token",
             type=str,
             default=read_github_token(),
             help="Github access token (optional if request limit exceeds)",
-        ),
-        CommonFlag(
-            "-r",
-            "--remote",
-            default="https://github.com/NixOS/nixpkgs",
-            help="Name of the nixpkgs repo to review",
-        ),
-        CommonFlag(
-            "--system",
-            type=str,
-            help="Nix 'system' to evaluate and build packages for",
         ),
     ]
 

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -66,7 +66,7 @@ def pr_command(args: argparse.Namespace) -> str:
                     skip_packages_regex=args.skip_package_regex,
                     system=args.system,
                     checkout=checkout_option,
-                    allowAliases=args.allow_aliases,
+                    allow_aliases=args.allow_aliases,
                 )
                 contexts.append((pr, builddir.path, review.build_pr(pr)))
             except subprocess.CalledProcessError:

--- a/nixpkgs_review/cli/rev.py
+++ b/nixpkgs_review/cli/rev.py
@@ -7,6 +7,6 @@ from ..utils import verify_commit_hash
 
 
 def rev_command(args: argparse.Namespace) -> Path:
-    with Buildenv():
+    with Buildenv(args):
         commit = verify_commit_hash(args.commit)
         return review_local_revision(f"rev-{commit}", args, commit)

--- a/nixpkgs_review/cli/wip.py
+++ b/nixpkgs_review/cli/wip.py
@@ -7,7 +7,7 @@ from ..utils import verify_commit_hash
 
 
 def wip_command(args: argparse.Namespace) -> Path:
-    with Buildenv():
+    with Buildenv(args):
         return review_local_revision(
             "rev-%s-dirty" % verify_commit_hash("HEAD"), args, None, args.staged
         )

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -134,13 +134,13 @@ def nix_build(
     args: str,
     cache_directory: Path,
     system: str,
-    allowAliases: bool,
+    allow_aliases: bool,
 ) -> List[Attr]:
     if not attr_names:
         info("Nothing to be built.")
         return []
 
-    attrs = nix_eval(attr_names, system, allowAliases)
+    attrs = nix_eval(attr_names, system, allow_aliases)
     filtered = []
     for attr in attrs:
         if not (attr.broken or attr.blacklisted):

--- a/nixpkgs_review/nix/evalAttrs.nix
+++ b/nixpkgs_review/nix/evalAttrs.nix
@@ -1,8 +1,8 @@
-attr-json:
+{ allowAliases ? false, attr-json }:
 
 with builtins;
 let
-  pkgs = import <nixpkgs> { config = { checkMeta = true; allowUnfree = true; }; };
+  pkgs = import <nixpkgs> { config = { checkMeta = true; allowUnfree = true; inherit allowAliases; }; };
   lib = pkgs.lib;
 
   attrs = fromJSON (readFile attr-json);

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -111,7 +111,7 @@ class Review:
         skip_packages_regex: List[Pattern[str]] = [],
         checkout: CheckoutOption = CheckoutOption.MERGE,
         system: Optional[str] = None,
-        allowAliases: bool = False,
+        allow_aliases: bool = False,
     ) -> None:
         self.builddir = builddir
         self.build_args = build_args
@@ -126,7 +126,7 @@ class Review:
         self.skip_packages = skip_packages
         self.skip_packages_regex = skip_packages_regex
         self.system = system or current_system()
-        self.allowAliases = allowAliases
+        self.allow_aliases = allow_aliases
 
     def worktree_dir(self) -> str:
         return str(self.builddir.worktree_dir)
@@ -193,10 +193,10 @@ class Review:
             self.skip_packages,
             self.skip_packages_regex,
             self.system,
-            self.allowAliases,
+            self.allow_aliases,
         )
         return nix_build(
-            packages, args, self.builddir.path, self.system, self.allowAliases
+            packages, args, self.builddir.path, self.system, self.allow_aliases
         )
 
     def build_pr(self, pr_number: int) -> List[Attr]:
@@ -339,13 +339,13 @@ def package_attrs(
     package_set: Set[str],
     system: str,
     ignore_nonexisting: bool = True,
-    allowAliases: bool = False,
+    allow_aliases: bool = False,
 ) -> Dict[str, Attr]:
     attrs: Dict[str, Attr] = {}
 
     nonexisting = []
 
-    for attr in nix_eval(package_set, system, allowAliases):
+    for attr in nix_eval(package_set, system, allow_aliases):
         if not attr.exists:
             nonexisting.append(attr.name)
         elif not attr.broken:
@@ -363,11 +363,11 @@ def join_packages(
     changed_packages: Set[str],
     specified_packages: Set[str],
     system: str,
-    allowAliases: bool,
+    allow_aliases: bool,
 ) -> Set[str]:
     changed_attrs = package_attrs(changed_packages, system)
     specified_attrs = package_attrs(
-        specified_packages, system, ignore_nonexisting=False, allowAliases=allowAliases
+        specified_packages, system, ignore_nonexisting=False, allow_aliases=allow_aliases
     )
 
     tests: Dict[str, Attr] = {}
@@ -396,7 +396,7 @@ def filter_packages(
     skip_packages: Set[str],
     skip_package_regexes: List[Pattern[str]],
     system: str,
-    allowAliases: bool,
+    allow_aliases: bool,
 ) -> Set[str]:
     packages: Set[str] = set()
 
@@ -410,7 +410,7 @@ def filter_packages(
 
     if len(specified_packages) > 0:
         packages = join_packages(
-            changed_packages, specified_packages, system, allowAliases
+            changed_packages, specified_packages, system, allow_aliases
         )
 
     for attr in changed_packages:


### PR DESCRIPTION
While evalling https://github.com/NixOS/nixpkgs/pull/131530 locally I got the following report.json

```
{
    "blacklisted": [],
    "broken": [],
    "built": [
        "libjpeg_drop",
        "lightworks"
    ],
    "failed": [],
    "non-existant": [],
    "pr": 131530,
    "system": "x86_64-linux",
    "tests": []
}
```

libjpeg_drop is an alias to libjpeg_original and because I have aliases disabled it does not work.