### PR TITLE
cli/__init__.py: support GitHub's auth token format in oauth_token

### DIFF
--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -121,7 +121,7 @@ def read_github_token() -> Optional[str]:
         try:
             with open(path) as f:
                 for line in f:
-                    token_match = re.match(r"\s*oauth_token:\s+([a-f0-9]+)", line)
+                    token_match = re.match(r"\s*oauth_token:\s+((?:ghp_)?[a-f0-9]+)", line)
                     if token_match:
                         return token_match.group(1)
         except OSError:


### PR DESCRIPTION
Use a non-capturing group to include `ghp_` prefixes in reading
`oauth_token` from `hub` config, while keeping compatibility with older
tokens (that the user should be refreshing soon.)

cf https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/