### PR TITLE
Do not fetch tags when fetching PR branches

### DIFF
--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -440,7 +440,7 @@ def filter_packages(
 
 
 def fetch_refs(repo: str, *refs: str) -> List[str]:
-    cmd = ["git", "-c", "fetch.prune=false", "fetch", "--force", repo]
+    cmd = ["git", "-c", "fetch.prune=false", "fetch", "--no-tags", "--force", repo]
     for i, ref in enumerate(refs):
         cmd.append(f"{ref}:refs/nixpkgs-review/{i}")
     sh(cmd)


### PR DESCRIPTION
The command to fetch the PR branches is also fetching all reachable tags from those references, but it's not something that it should be expected to do. In one-shot fetchs like that the tags are not relevant, as discussed in the man page of `git tag`.

Add the `--no-tags` flag to disable automatic tag following.

Closes #222.