### PR TITLE
fix reading github token from gh config

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Then use either the `GITHUB_TOKEN` environment variable or the `--token` paramet
 $ GITHUB_TOKEN=5ae04810f1e9f17c3297ee4c9e25f3ac1f437c26 nixpkgs-review pr  37244
 ```
 
-Additionally nixpkgs-review will also read the oauth_token stored by [hub](https://hub.github.com/).
+Additionally nixpkgs-review will also read the oauth_token stored by [hub](https://hub.github.com/) and [gh](https://cli.github.com/).
 
 
 ## Checkout strategy (recommend for r-ryantm + cachix)

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -122,7 +122,7 @@ def read_github_token() -> Optional[str]:
             with open(path) as f:
                 for line in f:
                     token_match = re.match(
-                        r"\s*oauth_token:\s+((?:ghp_)?[a-f0-9]+)", line
+                        r"\s*oauth_token:\s+((?:gh[po]_)?[A-z0-9]+)", line
                     )
                     if token_match:
                         return token_match.group(1)


### PR DESCRIPTION
In `~/.config/gh/hosts.yaml` I have:
```yaml
github.com:
    user: jyooru
    oauth_token: gho_secrettokenhere
    git_protocol: ssh
```
nixpkgs-review is already reading this file, but the regex failed to detect my token. This pull request fixes this.