### PR TITLE
Display better error message when evaling an attr set

### DIFF
--- a/nixpkgs_review/nix/evalAttrs.nix
+++ b/nixpkgs_review/nix/evalAttrs.nix
@@ -3,18 +3,35 @@
 with builtins;
 let
   pkgs = import <nixpkgs> { config = { checkMeta = true; allowUnfree = true; inherit allowAliases; }; };
-  lib = pkgs.lib;
+  inherit (pkgs) lib;
 
   attrs = fromJSON (readFile attr-json);
-  getProperties = name: let
-    attrPath = lib.splitString "." name;
-    pkg = lib.attrByPath attrPath null pkgs;
-    maybePath = builtins.tryEval "${pkg}";
-  in rec {
-    exists = lib.hasAttrByPath attrPath pkgs;
-    broken = !exists || !maybePath.success;
-    path = if !broken then maybePath.value else null;
-    drvPath = if !broken then pkg.drvPath else null;
-  };
+  getProperties = name:
+    let
+      attrPath = lib.splitString "." name;
+      pkg = lib.attrByPath attrPath null pkgs;
+      debugAttr = attr: lib.concatStringsSep "   " (lib.mapAttrsToList
+        (name: value: "${name}=${value}")
+        (lib.mapAttrs
+          (name: value:
+            if (isAttrs value && lib.hasAttr "outPath" value) then
+              value.outPath
+            else
+              "")
+          attr
+        )
+      );
+      maybePath =
+        if lib.strings.isCoercibleToString pkg then
+          tryEval "${pkg}"
+        else
+          throw "Tried building attr set with the following content: ${debugAttr pkg}";
+    in
+    rec {
+      exists = lib.hasAttrByPath attrPath pkgs;
+      broken = !exists || !maybePath.success;
+      path = if !broken then maybePath.value else null;
+      drvPath = if !broken then pkg.drvPath else null;
+    };
 in
-  pkgs.lib.genAttrs attrs getProperties
+pkgs.lib.genAttrs attrs getProperties


### PR DESCRIPTION
Related #185

```ShellSession
$ git -c fetch.prune=false fetch --no-tags --force https://github.com/NixOS/nixpkgs staging:refs/nixpkgs-review/0 pull/139808/head:refs/nixpkgs-review/1
From https://github.com/NixOS/nixpkgs
 + 9a4978f9cfb...40726812071 refs/pull/139808/head -> refs/nixpkgs-review/1  (forced update)
$ git worktree add /home/hotpi/.cache/nixpkgs-review/pr-139808-12/nixpkgs 845225e7ab34d00bae7b20f47d06c7418210a631
Preparing worktree (detached HEAD 845225e7ab3)
HEAD is now at 845225e7ab3 Merge pull request #147289 from midchildan/fix/libcxx13-darwin
$ git merge --no-commit --no-ff 40726812071e1fe0dbb9cb326b8bb4ab0cb4d7b6
Automatic merge went well; stopped before committing as requested
error: Tried building attr set with the following content: aarch64=/nix/store/bh24g8l4vlnf17hh6d6qp40i6fy3czvl-coreboot-toolchain-aarch64-4.15   arm=/nix/store/xaln448j4982kzcrqgfbxsd9wz888irb-coreboot-toolchain-arm-4.15   i386=/nix/store/3smj20p9kcsq7i0rcaqhgqijgr2p5ysk-coreboot-toolchain-i386-4.15   nds32le=/nix/store/ag1yry1rws27jw2dq1132818qfvm9wbm-coreboot-toolchain-nds32le-4.15   override=   overrideDerivation=   ppc64=/nix/store/l6wf06g65w768gkzqkcngr82nh5fjqqh-coreboot-toolchain-ppc64-4.15   recurseForDerivations=   riscv=/nix/store/b67nw64zv2dllcarb8cd6545akqgzwfn-coreboot-toolchain-riscv-4.15   x64=/nix/store/17y1agpgybp06f286m00gmdgc5vmcda4-coreboot-toolchain-x64-4.15
nix --experimental-features nix-command --system x86_64-linux eval --json --impure --expr (import /nix/store/zr8ajm22gqvb15qpwfq4z9g6izyw110z-nixpkgs-review/lib/python3.9/site-packages/nixpkgs_review/nix/evalAttrs.nix { allowAliases = false; attr-json = /tmp/tmpchah76g_; }) failed to run, /tmp/tmpchah76g_ was stored inspection
https://github.com/NixOS/nixpkgs/pull/139808 failed to build
$ git worktree prune
```