### PR TITLE
Fix error log generation

### DIFF
--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -79,7 +79,7 @@ def write_error_logs(attrs: List[Attr], directory: Path) -> None:
                     stdout=f,
                 )
                 if nix_log.returncode == 0:
-                    return
+                    break
 
 
 class Report:


### PR DESCRIPTION
Currently, only the log of the first derivative is saved and the function returns afterwards. Instead it should break and continue with the next derivation