### PR TITLE
cli: fix 'hub' token reading search

### DIFF
--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -136,8 +136,10 @@ def read_github_token() -> Optional[str]:
         try:
             with open(path) as f:
                 for line in f:
-                    token_match = re.match(
-                        r"\s*oauth_token:\s+((?:gh[po]_)?[A-z0-9]+)", line
+                    # Allow substring match as hub uses yaml. Example string we match:
+                    # " - oauth_token: ghp_.....\n"
+                    token_match = re.search(
+                        r"\s*oauth_token:\s+((?:gh[po]_)?[A-Za-z0-9]+)", line
                     )
                     if token_match:
                         return token_match.group(1)

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -137,7 +137,7 @@ def read_github_token() -> Optional[str]:
             with open(path) as f:
                 for line in f:
                     # Allow substring match as hub uses yaml. Example string we match:
-                    # " - oauth_token: ghp_.....\n"
+                    # " - oauth_token: ghp_abcdefghijklmnopqrstuvwxyzABCDEF1234\n"
                     token_match = re.search(
                         r"\s*oauth_token:\s+((?:gh[po]_)?[A-Za-z0-9]+)", line
                     )


### PR DESCRIPTION
Before the change re.match was not able to find hub key as
re.match does full string match.

After the change re.search uses substring match to be more
tolerant to yaml syntax.