### PR TITLE
Disable aliases by default

### DIFF
--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -151,10 +151,10 @@ def read_github_token() -> Optional[str]:
 def common_flags() -> List[CommonFlag]:
     return [
         CommonFlag(
-            "--disable-aliases",
+            "--allow-aliases",
             dest="allow_aliases",
-            action="store_false",
-            help="Disable aliases while evaluating locally. They are automatically disabled when reviewing NixOS/nixpkgs PRs against master.",
+            action="store_true",
+            help="Allow aliases while evaluating locally",
         ),
         CommonFlag(
             "--build-args", default="", help="arguments passed to nix when building"

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -38,11 +38,6 @@ def pr_command(args: argparse.Namespace) -> str:
         CheckoutOption.MERGE if args.checkout == "merge" else CheckoutOption.COMMIT
     )
 
-    if args.allow_aliases:
-        args.allow_aliases = (
-            getattr(args, "branch", "") == "master" or args.checkout == "merge"
-        ) and args.remote == "https://github.com/NixOS/nixpkgs"
-
     if args.post_result:
         ensure_github_token(args.token)
 


### PR DESCRIPTION
Ofborg does a check with `allowAliases = false;`. So it's safe to assume that our evaluation shouldn't have to worry about them either.

```
 ofborg-eval-package-list-no-aliases — nix-env -qa --json --file . --arg config { allowAliases = false; }
```

related: https://github.com/Mic92/nixpkgs-review/pull/254