### PR TITLE
Disable external git diff tools when patching

### DIFF
--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -118,7 +118,7 @@ class Review:
         sh(["git", "merge", "--no-commit", "--no-ff", commit], cwd=self.worktree_dir())
 
     def apply_unstaged(self, staged: bool = False) -> None:
-        args = ["git", "--no-pager", "diff"]
+        args = ["git", "--no-pager", "diff", "--no-ext-diff"]
         args.extend(["--staged"] if staged else [])
         diff_proc = subprocess.Popen(args, stdout=subprocess.PIPE)
         assert diff_proc.stdout


### PR DESCRIPTION
The GIT_EXTERNAL_DIFF environment variable can be configured to use a
custom diff tool for interactive diff commands, but it may not produce
an output compatible with `git apply`, so `--no-ext-diff` should be
used to ensure that the diff output is usable for this purpose.