### PR TITLE
make --system work better with the shell

### DIFF
--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -275,7 +275,7 @@ let
   paths = [
 """
         )
-        f.write("\n".join(f"        {escape_attr(a)}" for a in attrs))
+        f.write("\n".join(f"    {escape_attr(a)}" for a in attrs))
         f.write(
             """
   ];
@@ -284,14 +284,12 @@ let
     inherit paths;
     ignoreCollisions = true;
   };
-in stdenv.mkDerivation rec {
+in (import ./nixpkgs { }).mkShell {
   name = "review-shell";
   preferLocalBuild = true;
   allowSubstitutes = false;
   dontWrapQtApps = true;
-  buildInputs = if builtins.length paths > 50 then [ env ] else paths;
-  unpackPhase = ":";
-  installPhase = "touch $out";
+  packages = if builtins.length paths > 50 then [ env ] else paths;
 }
 """
         )

--- a/tests/assets/nixpkgs/default.nix
+++ b/tests/assets/nixpkgs/default.nix
@@ -12,5 +12,5 @@ in {
     '';
   };
   # hack to not break evaluation with nixpkgs_review/nix/*.nix
-  inherit (pkgs) lib stdenv bashInteractive;
+  inherit (pkgs) lib mkShell bashInteractive;
 }


### PR DESCRIPTION
without this pr (on nixos):

```console
$ nixpkgs-review rev HEAD --system aarch64-darwin
[...]

$ ls
bash: /nix/store/npcq66nqv2wpzp3ma5s63vafnnivphxb-coreutils-9.1/bin/ls: cannot execute binary file: Exec format error
```

this pr changes so the shell is built with the local system, and the snippet works