### PR TITLE
ignore darwin.builder

### DIFF
--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -140,6 +140,7 @@ def _nix_eval_filter(json: Dict[str, Any]) -> List[Attr]:
     blacklist = set(
         [
             "appimage-run-tests",
+            "darwin.builder",
             "nixos-install-tools",
             "tests.nixos-functions.nixos-test",
             "tests.nixos-functions.nixosTest-test",


### PR DESCRIPTION
I ended up trying to build the linux kernel due to darwin.builder, I think it is safe to ignore it