### PR TITLE
disallow url literals by default

### DIFF
--- a/nixpkgs_review/allow.py
+++ b/nixpkgs_review/allow.py
@@ -1,0 +1,17 @@
+from typing import List
+
+
+class AllowedFeatures:
+    aliases: bool = False
+    ifd: bool = False
+    url_literals: bool = False
+
+    def __init__(self, features: List[str]) -> None:
+        for feature in features:
+            # ruff doesn't support match statements yet
+            if feature == "aliases":
+                self.aliases = True
+            elif feature == "ifd":
+                self.ifd = True
+            elif feature == "url-literals":
+                self.url_literals = True

--- a/nixpkgs_review/buildenv.py
+++ b/nixpkgs_review/buildenv.py
@@ -1,4 +1,4 @@
-import argparse
+from dataclasses import dataclass
 import os
 import sys
 from tempfile import NamedTemporaryFile
@@ -20,9 +20,9 @@ def find_nixpkgs_root() -> Optional[str]:
         prefix.append("..")
 
 
+@dataclass
 class Buildenv:
-    def __init__(self, args: argparse.Namespace):
-        self.args = args
+    allow_aliases: bool
 
     def __enter__(self) -> None:
         self.environ = os.environ.copy()
@@ -41,7 +41,7 @@ class Buildenv:
                 f"""{{
           allowUnfree = true;
           allowBroken = true;
-          {"allowAliases = false;" if not self.args.allow_aliases else ""}
+          {"allowAliases = false;" if not self.allow_aliases else ""}
           ## TODO also build packages marked as insecure
           #allowInsecurePredicate = x: true;
         }}"""

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -152,22 +152,11 @@ def read_github_token() -> Optional[str]:
 def common_flags() -> List[CommonFlag]:
     return [
         CommonFlag(
-            "--allow-aliases",
-            dest="allow_aliases",
-            action="store_true",
-            help="Allow aliases while evaluating locally",
-        ),
-        CommonFlag(
-            "--allow-ifd",
-            "--allow-import-from-derivation",
-            dest="allow_ifd",
-            action="store_true",
-            help="Allow import-from-derivation",
-        ),
-        CommonFlag(
-            "--allow-url-literals",
-            action="store_true",
-            help="Allow url literals",
+            "--allow",
+            action="append",
+            default=[],
+            choices=["aliases", "ifd", "url-literals"],
+            help="Allow features that are normally disabled, can be passed multiple times",
         ),
         CommonFlag(
             "--build-args", default="", help="arguments passed to nix when building"

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -165,6 +165,11 @@ def common_flags() -> List[CommonFlag]:
             help="Allow import-from-derivation",
         ),
         CommonFlag(
+            "--allow-url-literals",
+            action="store_true",
+            help="Allow url literals",
+        ),
+        CommonFlag(
             "--build-args", default="", help="arguments passed to nix when building"
         ),
         CommonFlag(

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -63,6 +63,7 @@ def pr_command(args: argparse.Namespace) -> str:
                     checkout=checkout_option,
                     allow_aliases=args.allow_aliases,
                     allow_ifd=args.allow_ifd,
+                    allow_url_literals=args.allow_url_literals,
                     sandbox=args.sandbox,
                 )
                 contexts.append((pr, builddir.path, review.build_pr(pr)))

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -5,6 +5,7 @@ import sys
 from contextlib import ExitStack
 from typing import List
 
+from ..allow import AllowedFeatures
 from ..builddir import Builddir
 from ..buildenv import Buildenv
 from ..review import CheckoutOption, Review
@@ -43,7 +44,9 @@ def pr_command(args: argparse.Namespace) -> str:
 
     contexts = []
 
-    with Buildenv(args), ExitStack() as stack:
+    allow = AllowedFeatures(args.allow)
+
+    with Buildenv(allow.aliases), ExitStack() as stack:
         for pr in prs:
             builddir = stack.enter_context(Builddir(f"pr-{pr}"))
             try:
@@ -60,10 +63,8 @@ def pr_command(args: argparse.Namespace) -> str:
                     skip_packages=set(args.skip_package),
                     skip_packages_regex=args.skip_package_regex,
                     system=args.system,
+                    allow=allow,
                     checkout=checkout_option,
-                    allow_aliases=args.allow_aliases,
-                    allow_ifd=args.allow_ifd,
-                    allow_url_literals=args.allow_url_literals,
                     sandbox=args.sandbox,
                 )
                 contexts.append((pr, builddir.path, review.build_pr(pr)))

--- a/nixpkgs_review/cli/rev.py
+++ b/nixpkgs_review/cli/rev.py
@@ -1,12 +1,14 @@
 import argparse
 from pathlib import Path
 
+from ..allow import AllowedFeatures
 from ..buildenv import Buildenv
 from ..review import review_local_revision
 from ..utils import verify_commit_hash
 
 
 def rev_command(args: argparse.Namespace) -> Path:
-    with Buildenv(args):
+    allow = AllowedFeatures(args.allow)
+    with Buildenv(allow.aliases):
         commit = verify_commit_hash(args.commit)
-        return review_local_revision(f"rev-{commit}", args, commit)
+        return review_local_revision(f"rev-{commit}", args, allow, commit)

--- a/nixpkgs_review/cli/wip.py
+++ b/nixpkgs_review/cli/wip.py
@@ -1,13 +1,15 @@
 import argparse
 from pathlib import Path
 
+from ..allow import AllowedFeatures
 from ..buildenv import Buildenv
 from ..review import review_local_revision
 from ..utils import verify_commit_hash
 
 
 def wip_command(args: argparse.Namespace) -> Path:
-    with Buildenv(args):
+    allow = AllowedFeatures(args.allow)
+    with Buildenv(allow.aliases):
         return review_local_revision(
-            "rev-%s-dirty" % verify_commit_hash("HEAD"), args, None, args.staged
+            "rev-%s-dirty" % verify_commit_hash("HEAD"), args, allow, None, args.staged
         )

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -9,6 +9,7 @@ from sys import platform
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, List, Optional, Set, Union
 
+from .allow import AllowedFeatures
 from .utils import ROOT, escape_attr, info, sh, warn
 
 
@@ -179,9 +180,7 @@ def _nix_eval_filter(json: Dict[str, Any]) -> List[Attr]:
 def nix_eval(
     attrs: Set[str],
     system: str,
-    allow_aliases: bool,
-    allow_ifd: bool,
-    allow_url_literals: bool,
+    allow: AllowedFeatures,
 ) -> List[Attr]:
     attr_json = NamedTemporaryFile(mode="w+", delete=False)
     delete = True
@@ -189,18 +188,18 @@ def nix_eval(
         json.dump(list(attrs), attr_json)
         eval_script = str(ROOT.joinpath("nix/evalAttrs.nix"))
         attr_json.flush()
-        allowAliases = "true" if allow_aliases else "false"
+        allowAliases = "true" if allow.aliases else "false"
         cmd = [
             "nix",
             "--experimental-features",
-            "nix-command" if allow_url_literals else "nix-command no-url-literals",
+            "nix-command" if allow.url_literals else "nix-command no-url-literals",
             "--system",
             system,
             "eval",
             "--json",
             "--impure",
             "--allow-import-from-derivation"
-            if allow_ifd
+            if allow.ifd
             else "--no-allow-import-from-derivation",
             "--expr",
             f"(import {eval_script} {{ allowAliases = {allowAliases}; attr-json = {attr_json.name}; }})",
@@ -229,15 +228,13 @@ def nix_build(
     args: str,
     cache_directory: Path,
     system: str,
-    allow_aliases: bool,
-    allow_ifd: bool,
-    allow_url_literals: bool,
+    allow: AllowedFeatures,
 ) -> List[Attr]:
     if not attr_names:
         info("Nothing to be built.")
         return []
 
-    attrs = nix_eval(attr_names, system, allow_aliases, allow_ifd, allow_url_literals)
+    attrs = nix_eval(attr_names, system, allow)
     filtered = []
     for attr in attrs:
         if not (attr.broken or attr.blacklisted):
@@ -252,12 +249,12 @@ def nix_build(
     command = [
         "nix",
         "--experimental-features",
-        "nix-command" if allow_url_literals else "nix-command no-url-literals",
+        "nix-command" if allow.url_literals else "nix-command no-url-literals",
         "build",
         "--no-link",
         "--keep-going",
         "--allow-import-from-derivation"
-        if allow_ifd
+        if allow.ifd
         else "--no-allow-import-from-derivation",
     ]
 

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -177,7 +177,11 @@ def _nix_eval_filter(json: Dict[str, Any]) -> List[Attr]:
 
 
 def nix_eval(
-    attrs: Set[str], system: str, allow_aliases: bool, allow_ifd: bool
+    attrs: Set[str],
+    system: str,
+    allow_aliases: bool,
+    allow_ifd: bool,
+    allow_url_literals: bool,
 ) -> List[Attr]:
     attr_json = NamedTemporaryFile(mode="w+", delete=False)
     delete = True
@@ -189,7 +193,7 @@ def nix_eval(
         cmd = [
             "nix",
             "--experimental-features",
-            "nix-command",
+            "nix-command" if allow_url_literals else "nix-command no-url-literals",
             "--system",
             system,
             "eval",
@@ -227,12 +231,13 @@ def nix_build(
     system: str,
     allow_aliases: bool,
     allow_ifd: bool,
+    allow_url_literals: bool,
 ) -> List[Attr]:
     if not attr_names:
         info("Nothing to be built.")
         return []
 
-    attrs = nix_eval(attr_names, system, allow_aliases, allow_ifd)
+    attrs = nix_eval(attr_names, system, allow_aliases, allow_ifd, allow_url_literals)
     filtered = []
     for attr in attrs:
         if not (attr.broken or attr.blacklisted):
@@ -247,7 +252,7 @@ def nix_build(
     command = [
         "nix",
         "--experimental-features",
-        "nix-command",
+        "nix-command" if allow_url_literals else "nix-command no-url-literals",
         "build",
         "--no-link",
         "--keep-going",

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -9,6 +9,7 @@ from enum import Enum
 from pathlib import Path
 from typing import IO, Dict, List, Optional, Pattern, Set, Tuple
 
+from .allow import AllowedFeatures
 from .builddir import Builddir
 from .github import GithubClient
 from .nix import Attr, nix_build, nix_eval, nix_shell
@@ -85,6 +86,7 @@ class Review:
         run: str,
         remote: str,
         system: str,
+        allow: AllowedFeatures,
         api_token: Optional[str] = None,
         use_ofborg_eval: Optional[bool] = True,
         only_packages: Set[str] = set(),
@@ -92,9 +94,6 @@ class Review:
         skip_packages: Set[str] = set(),
         skip_packages_regex: List[Pattern[str]] = [],
         checkout: CheckoutOption = CheckoutOption.MERGE,
-        allow_aliases: bool = False,
-        allow_ifd: bool = False,
-        allow_url_literals: bool = False,
         sandbox: bool = False,
     ) -> None:
         self.builddir = builddir
@@ -110,9 +109,7 @@ class Review:
         self.skip_packages = skip_packages
         self.skip_packages_regex = skip_packages_regex
         self.system = system
-        self.allow_aliases = allow_aliases
-        self.allow_ifd = allow_ifd
-        self.allow_url_literals = allow_url_literals
+        self.allow = allow
         self.sandbox = sandbox
 
     def worktree_dir(self) -> str:
@@ -149,8 +146,7 @@ class Review:
         base_packages = list_packages(
             str(self.worktree_dir()),
             self.system,
-            allow_ifd=self.allow_ifd,
-            allow_url_literals=self.allow_url_literals,
+            self.allow,
         )
 
         if reviewed_commit is None:
@@ -161,9 +157,8 @@ class Review:
         merged_packages = list_packages(
             str(self.worktree_dir()),
             self.system,
+            self.allow,
             check_meta=True,
-            allow_ifd=self.allow_ifd,
-            allow_url_literals=self.allow_url_literals,
         )
 
         changed_pkgs, removed_pkgs = differences(base_packages, merged_packages)
@@ -189,18 +184,14 @@ class Review:
             self.skip_packages,
             self.skip_packages_regex,
             self.system,
-            self.allow_aliases,
-            self.allow_ifd,
-            self.allow_url_literals,
+            self.allow,
         )
         return nix_build(
             packages,
             args,
             self.builddir.path,
             self.system,
-            self.allow_aliases,
-            self.allow_ifd,
-            self.allow_url_literals,
+            self.allow,
         )
 
     def build_pr(self, pr_number: int) -> List[Attr]:
@@ -321,14 +312,13 @@ def parse_packages_xml(stdout: IO[str]) -> List[Package]:
 def list_packages(
     path: str,
     system: str,
+    allow: AllowedFeatures,
     check_meta: bool = False,
-    allow_ifd: bool = False,
-    allow_url_literals: bool = False,
 ) -> List[Package]:
     cmd = [
         "nix-env",
         "--experimental-features",
-        "" if allow_url_literals else "no-url-literals",
+        "" if allow.url_literals else "no-url-literals",
         "--option",
         "system",
         system,
@@ -339,7 +329,7 @@ def list_packages(
         "--out-path",
         "--show-trace",
         "--allow-import-from-derivation"
-        if allow_ifd
+        if allow.ifd
         else "--no-allow-import-from-derivation",
     ]
     if check_meta:
@@ -355,18 +345,14 @@ def list_packages(
 def package_attrs(
     package_set: Set[str],
     system: str,
+    allow: AllowedFeatures,
     ignore_nonexisting: bool = True,
-    allow_aliases: bool = False,
-    allow_ifd: bool = False,
-    allow_url_literals: bool = False,
 ) -> Dict[str, Attr]:
     attrs: Dict[str, Attr] = {}
 
     nonexisting = []
 
-    for attr in nix_eval(
-        package_set, system, allow_aliases, allow_ifd, allow_url_literals
-    ):
+    for attr in nix_eval(package_set, system, allow):
         if not attr.exists:
             nonexisting.append(attr.name)
         elif not attr.broken:
@@ -384,18 +370,14 @@ def join_packages(
     changed_packages: Set[str],
     specified_packages: Set[str],
     system: str,
-    allow_aliases: bool,
-    allow_ifd: bool,
-    allow_url_literals: bool,
+    allow: AllowedFeatures,
 ) -> Set[str]:
-    changed_attrs = package_attrs(changed_packages, system)
+    changed_attrs = package_attrs(changed_packages, system, allow)
     specified_attrs = package_attrs(
         specified_packages,
         system,
+        allow,
         ignore_nonexisting=False,
-        allow_aliases=allow_aliases,
-        allow_ifd=allow_ifd,
-        allow_url_literals=allow_url_literals,
     )
 
     tests: Dict[str, Attr] = {}
@@ -424,9 +406,7 @@ def filter_packages(
     skip_packages: Set[str],
     skip_package_regexes: List[Pattern[str]],
     system: str,
-    allow_aliases: bool,
-    allow_ifd: bool,
-    allow_url_literals: bool,
+    allow: AllowedFeatures,
 ) -> Set[str]:
     packages: Set[str] = set()
 
@@ -443,9 +423,7 @@ def filter_packages(
             changed_packages,
             specified_packages,
             system,
-            allow_aliases,
-            allow_ifd,
-            allow_url_literals,
+            allow,
         )
 
     for attr in changed_packages:
@@ -504,6 +482,7 @@ def differences(
 def review_local_revision(
     builddir_path: str,
     args: argparse.Namespace,
+    allow: AllowedFeatures,
     commit: Optional[str],
     staged: bool = False,
 ) -> Path:
@@ -517,8 +496,7 @@ def review_local_revision(
             only_packages=set(args.package),
             package_regexes=args.package_regex,
             system=args.system,
-            allow_ifd=args.allow_ifd,
-            allow_url_literals=args.allow_url_literals,
+            allow=allow,
         )
         review.review_commit(builddir.path, args.branch, commit, staged)
         return builddir.path


### PR DESCRIPTION
this is the default behavior for ofborg and hydra: https://github.com/NixOS/ofborg/pull/628

also adds `--allow-url-literals`