### PR TITLE
treewide: replace --experimental-features with --extra-experimental-features

### DIFF
--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -191,7 +191,7 @@ def nix_eval(
         allowAliases = "true" if allow.aliases else "false"
         cmd = [
             "nix",
-            "--experimental-features",
+            "--extra-experimental-features",
             "nix-command" if allow.url_literals else "nix-command no-url-literals",
             "--system",
             system,
@@ -248,7 +248,7 @@ def nix_build(
 
     command = [
         "nix",
-        "--experimental-features",
+        "--extra-experimental-features",
         "nix-command" if allow.url_literals else "nix-command no-url-literals",
         "build",
         "--no-link",

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -74,7 +74,7 @@ def write_error_logs(attrs: List[Attr], directory: Path) -> None:
                 nix_log = subprocess.run(
                     [
                         "nix",
-                        "--experimental-features",
+                        "--extra-experimental-features",
                         "nix-command",
                         "log",
                         path,

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -317,7 +317,7 @@ def list_packages(
 ) -> List[Package]:
     cmd = [
         "nix-env",
-        "--experimental-features",
+        "--extra-experimental-features",
         "" if allow.url_literals else "no-url-literals",
         "--option",
         "system",

--- a/nixpkgs_review/utils.py
+++ b/nixpkgs_review/utils.py
@@ -49,7 +49,7 @@ def current_system() -> str:
     system = subprocess.run(
         [
             "nix",
-            "--experimental-features",
+            "--extra-experimental-features",
             "nix-command",
             "eval",
             "--impure",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ def real_nixpkgs() -> str:
         [
             "nix",
             "eval",
-            "--experimental-features",
+            "--extra-experimental-features",
             "nix-command flakes",
             "--raw",
             "nixpkgs#path",


### PR DESCRIPTION
otherwise experimental-features configured in nix.conf is overridden