### PR TITLE
enable bubblewrap feature in devShell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -17,7 +17,7 @@ python3.pkgs.buildPythonApplication rec {
     python3.pkgs.pytest
     pkgs.nixVersions.stable or nix_2_4
     git
-  ];
+  ] ++ lib.optional withSandboxSupport bubblewrap;
 
   checkPhase = ''
     ${if pkgs.lib.versionAtLeast python3.pkgs.black.version "20" then ''
@@ -45,6 +45,4 @@ python3.pkgs.buildPythonApplication rec {
   shellHook = ''
     # workaround because `python setup.py develop` breaks for me
   '';
-
-  passthru.env = buildEnv { inherit name; paths = buildInputs ++ checkInputs; };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,9 @@
         };
 
         packages.default = self.packages.${system}.nixpkgs-review;
+
+        devShells.default = self.packages.${system}.nixpkgs-review-sandbox
+          or self.packages.${system}.nixpkgs-review;
       }))
 
       (flake-utils.lib.eachSystem [ "aarch64-linux" "i686-linux" "x86_64-linux" ] (system: {

--- a/shell.nix
+++ b/shell.nix
@@ -2,10 +2,6 @@
 
 with pkgs;
 
-pkgs.mkShell {
-  buildInputs = [
-    (import ./. { }).passthru.env
-  ] ++ lib.optional stdenv.isLinux [
-    bubblewrap
-  ];
+callPackage ./. {
+  withSandboxSupport = stdenv.isLinux;
 }


### PR DESCRIPTION
cherry-picked from #296, this makes sure that the bubblewrap tests are ran in ci since the conversion to flakes in #300