### PR TITLE
feature: add `--nom` flag to enable nix-output-monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,7 @@ nix-shell> nixpkgs-review comments
 ```
 
 `nixpkgs-review` will by default use [nix-output-monitor](https://git.maralorn.de/nix-output-monitor/about/) if found in `$PATH`.
-If you have a custom path to `nom`, this can be passed with the `--nom-path` flag.
-Also, if you have `nom` installed but don't want to use it, you can pass an empty string to `--nom-path` to use `nix build` instead of `nom build`.
+If you have `nom` installed but don't want to use it, you can pass `nix` to `--nix-flavor` to use `nix build` instead of `nom build`.
 
 ## Using nixpkgs-review in scripts or other programs
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ nix-shell> nixpkgs-review post-result
 nix-shell> nixpkgs-review comments
 ```
 
-For larger rebuilds, it can come in handy to see which packages still need to be build. This can be achieved with the `--nom` flag. This enables the `nix-output-monitor` (https://git.maralorn.de/nix-output-monitor/about/) which informs about remote builders, down- and uploads and displays a build graph.
+For larger rebuilds, it can come in handy to see which packages still need to be build. This can be achieved with the `--nom` flag. This enables the [nix-output-monitor](https://git.maralorn.de/nix-output-monitor/about/) which informs about remote builders, down- and uploads and displays a build graph.
 
 To use this feature, make sure to install `nix-output-monitor` first.
 

--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ nix-shell> nixpkgs-review post-result
 nix-shell> nixpkgs-review comments
 ```
 
-`nixpkgs-review` will by default use [nix-output-monitor](https://git.maralorn.de/nix-output-monitor/about/) if found in `$PATH`.
-If you have `nom` installed but don't want to use it, you can pass `nix` to `--nix-flavor` to use `nix build` instead of `nom build`.
+`nixpkgs-review` will by default use [nix-output-monitor](https://github.com/maralorn/nix-output-monitor) if found in `$PATH`.
+If you have `nom` installed but don't want to use it, you can pass `nix` to `--build-graph` to use `nix build` instead of `nom build`.
 
 ## Using nixpkgs-review in scripts or other programs
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ nix-shell> nixpkgs-review post-result
 nix-shell> nixpkgs-review comments
 ```
 
+For larger rebuilds, it can come in handy to see which packages still need to be build. This can be achieved with the `--nom` flag. This enables the `nix-output-monitor` (https://git.maralorn.de/nix-output-monitor/about/) which informs about remote builders, down- and uploads and displays a build graph.
+
+To use this feature, make sure to install `nix-output-monitor` first.
+
 ## Using nixpkgs-review in scripts or other programs
 
 After building, `nixpkgs-review` will normally start a `nix-shell` with the

--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ nix-shell> nixpkgs-review post-result
 nix-shell> nixpkgs-review comments
 ```
 
-For larger rebuilds, it can come in handy to see which packages still need to be build. This can be achieved with the `--nom` flag. This enables the [nix-output-monitor](https://git.maralorn.de/nix-output-monitor/about/) which informs about remote builders, down- and uploads and displays a build graph.
-
-To use this feature, make sure to install `nix-output-monitor` first.
+`nixpkgs-review` will by default use [nix-output-monitor](https://git.maralorn.de/nix-output-monitor/about/) if found in `$PATH`.
+If you have a custom path to `nom`, this can be passed with the `--nom-path` flag.
+Also, if you have `nom` installed but don't want to use it, you can pass an empty string to `--nom-path` to use `nix build` instead of `nom build`.
 
 ## Using nixpkgs-review in scripts or other programs
 

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -228,7 +228,7 @@ def common_flags() -> List[CommonFlag]:
             type=str,
             default=nix_nom_tool(),
             choices=["nix", "nom"],
-            help='Build graph to use. Use either "nom" or "nix". Will default to "nom" if available',
+            help='Build graph to print. Use either "nom" or "nix". Will default to "nom" if available',
         ),
     ]
 

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import re
+import shutil
 import sys
 from pathlib import Path
 from typing import Any, List, Optional, Pattern, cast
@@ -223,6 +224,11 @@ def common_flags() -> List[CommonFlag]:
             default=read_github_token(),
             help="Github access token (optional if request limit exceeds)",
         ),
+        CommonFlag(
+            "--nom",
+            action="store_true",
+            help="Use nix-output-monitor (nom) instead of nix. Provides a nice realtime build graph",
+        ),
     ]
 
 
@@ -285,6 +291,13 @@ def check_common_flags(args: argparse.Namespace) -> bool:
     elif args.no_shell:
         print("--no-shell and --run are mutually exclusive", file=sys.stderr)
         return False
+    if args.nom:
+        if not shutil.which("nom"):
+            print(
+                "Cannot find nix-output-monitor. Please install it first if you want to use it",
+                file=sys.stderr,
+            )
+            return False
     return True
 
 

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -224,11 +224,11 @@ def common_flags() -> List[CommonFlag]:
             help="Github access token (optional if request limit exceeds)",
         ),
         CommonFlag(
-            "--nix-flavor",
+            "--build-graph",
             type=str,
             default=nix_nom_tool(),
             choices=["nix", "nom"],
-            help='Build flavor to use. Use either "nom" or "nix". Will default to "nom" if available',
+            help='Build graph to use. Use either "nom" or "nix". Will default to "nom" if available',
         ),
     ]
 

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -1,7 +1,6 @@
 import argparse
 import os
 import re
-import shutil
 import sys
 from pathlib import Path
 from typing import Any, List, Optional, Pattern, cast
@@ -13,7 +12,7 @@ from .post_result import post_result_command
 from .pr import pr_command
 from .rev import rev_command
 from .wip import wip_command
-from ..utils import current_system
+from ..utils import current_system, nix_nom_tool
 
 
 def regex_type(s: str) -> Pattern[str]:
@@ -225,9 +224,10 @@ def common_flags() -> List[CommonFlag]:
             help="Github access token (optional if request limit exceeds)",
         ),
         CommonFlag(
-            "--nom",
-            action="store_true",
-            help="Use nix-output-monitor (nom) instead of nix. Provides a nice realtime build graph",
+            "--nom-path",
+            type=str,
+            default=nix_nom_tool(),
+            help='Path to nix-output-monitor (nom). Set to "" if you want to disable nom',
         ),
     ]
 
@@ -291,13 +291,6 @@ def check_common_flags(args: argparse.Namespace) -> bool:
     elif args.no_shell:
         print("--no-shell and --run are mutually exclusive", file=sys.stderr)
         return False
-    if args.nom:
-        if not shutil.which("nom"):
-            print(
-                "Cannot find nix-output-monitor. Please install it first if you want to use it",
-                file=sys.stderr,
-            )
-            return False
     return True
 
 

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -224,10 +224,11 @@ def common_flags() -> List[CommonFlag]:
             help="Github access token (optional if request limit exceeds)",
         ),
         CommonFlag(
-            "--nom-path",
+            "--nix-flavor",
             type=str,
             default=nix_nom_tool(),
-            help='Path to nix-output-monitor (nom). Set to "" if you want to disable nom',
+            choices=["nix", "nom"],
+            help='Build flavor to use. Use either "nom" or "nix". Will default to "nom" if available',
         ),
     ]
 

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -66,6 +66,7 @@ def pr_command(args: argparse.Namespace) -> str:
                     allow=allow,
                     checkout=checkout_option,
                     sandbox=args.sandbox,
+                    nom=args.nom,
                 )
                 contexts.append((pr, builddir.path, review.build_pr(pr)))
             except subprocess.CalledProcessError:

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -66,7 +66,7 @@ def pr_command(args: argparse.Namespace) -> str:
                     allow=allow,
                     checkout=checkout_option,
                     sandbox=args.sandbox,
-                    nom_path=args.nom_path,
+                    nix_flavor=args.nix_flavor,
                 )
                 contexts.append((pr, builddir.path, review.build_pr(pr)))
             except subprocess.CalledProcessError:

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -66,7 +66,7 @@ def pr_command(args: argparse.Namespace) -> str:
                     allow=allow,
                     checkout=checkout_option,
                     sandbox=args.sandbox,
-                    nom=args.nom,
+                    nom_path=args.nom_path,
                 )
                 contexts.append((pr, builddir.path, review.build_pr(pr)))
             except subprocess.CalledProcessError:

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -66,7 +66,7 @@ def pr_command(args: argparse.Namespace) -> str:
                     allow=allow,
                     checkout=checkout_option,
                     sandbox=args.sandbox,
-                    nix_flavor=args.nix_flavor,
+                    build_graph=args.build_graph,
                 )
                 contexts.append((pr, builddir.path, review.build_pr(pr)))
             except subprocess.CalledProcessError:

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -45,16 +45,13 @@ def nix_shell(
     attrs: List[str],
     cache_directory: Path,
     system: str,
-    nom_path: str,
+    nix_flavor: str,
     run: Optional[str] = None,
     sandbox: bool = False,
 ) -> None:
-    shell_cmd = "nix-shell"
-    if nom_path:
-        shell_cmd = f"{nom_path}-shell"
-    nix_shell = shutil.which(shell_cmd)
+    nix_shell = shutil.which(nix_flavor)
     if not nix_shell:
-        raise RuntimeError(f"{shell_cmd} not found in PATH")
+        raise RuntimeError(f"{nix_flavor} not found in PATH")
 
     shell = cache_directory.joinpath("shell.nix")
     write_shell_expression(shell, attrs, system)
@@ -233,7 +230,7 @@ def nix_build(
     cache_directory: Path,
     system: str,
     allow: AllowedFeatures,
-    nom_path: str,
+    nix_flavor: str,
 ) -> List[Attr]:
     if not attr_names:
         info("Nothing to be built.")
@@ -251,10 +248,8 @@ def nix_build(
     build = cache_directory.joinpath("build.nix")
     write_shell_expression(build, filtered, system)
 
-    if not nom_path:
-        nom_path = "nix"
     command = [
-        nom_path,
+        nix_flavor,
         "build",
         "--extra-experimental-features",
         "nix-command" if allow.url_literals else "nix-command no-url-literals",

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -45,13 +45,13 @@ def nix_shell(
     attrs: List[str],
     cache_directory: Path,
     system: str,
+    nom_path: str,
     run: Optional[str] = None,
     sandbox: bool = False,
-    nom: bool = False,
 ) -> None:
     shell_cmd = "nix-shell"
-    if nom:
-        shell_cmd = "nom-shell"
+    if nom_path:
+        shell_cmd = f"{nom_path}-shell"
     nix_shell = shutil.which(shell_cmd)
     if not nix_shell:
         raise RuntimeError(f"{shell_cmd} not found in PATH")
@@ -233,7 +233,7 @@ def nix_build(
     cache_directory: Path,
     system: str,
     allow: AllowedFeatures,
-    nom: bool,
+    nom_path: str,
 ) -> List[Attr]:
     if not attr_names:
         info("Nothing to be built.")
@@ -251,12 +251,10 @@ def nix_build(
     build = cache_directory.joinpath("build.nix")
     write_shell_expression(build, filtered, system)
 
-    nix_cmd = "nix"
-    if nom:
-        nix_cmd = "nom"
-
+    if not nom_path:
+        nom_path = "nix"
     command = [
-        nix_cmd,
+        nom_path,
         "build",
         "--extra-experimental-features",
         "nix-command" if allow.url_literals else "nix-command no-url-literals",

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -229,6 +229,7 @@ def nix_build(
     cache_directory: Path,
     system: str,
     allow: AllowedFeatures,
+    nom: bool,
 ) -> List[Attr]:
     if not attr_names:
         info("Nothing to be built.")
@@ -246,17 +247,30 @@ def nix_build(
     build = cache_directory.joinpath("build.nix")
     write_shell_expression(build, filtered, system)
 
-    command = [
-        "nix",
-        "--extra-experimental-features",
-        "nix-command" if allow.url_literals else "nix-command no-url-literals",
-        "build",
-        "--no-link",
-        "--keep-going",
-        "--allow-import-from-derivation"
-        if allow.ifd
-        else "--no-allow-import-from-derivation",
-    ]
+    if nom:
+        command = [
+            "nom",
+            "build",
+            "--extra-experimental-features",
+            "nix-command" if allow.url_literals else "nix-command no-url-literals",
+            "--no-link",
+            "--keep-going",
+            "--allow-import-from-derivation"
+            if allow.ifd
+            else "--no-allow-import-from-derivation",
+        ]
+    else:
+        command = [
+            "nix",
+            "--extra-experimental-features",
+            "nix-command" if allow.url_literals else "nix-command no-url-literals",
+            "build",
+            "--no-link",
+            "--keep-going",
+            "--allow-import-from-derivation"
+            if allow.ifd
+            else "--no-allow-import-from-derivation",
+        ]
 
     if platform == "linux":
         command += [

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -47,10 +47,14 @@ def nix_shell(
     system: str,
     run: Optional[str] = None,
     sandbox: bool = False,
+    nom: bool = False,
 ) -> None:
-    nix_shell = shutil.which("nix-shell")
+    shell_cmd = "nix-shell"
+    if nom:
+        shell_cmd = "nom-shell"
+    nix_shell = shutil.which(shell_cmd)
     if not nix_shell:
-        raise RuntimeError("nix-shell not found in PATH")
+        raise RuntimeError(f"{shell_cmd} not found in PATH")
 
     shell = cache_directory.joinpath("shell.nix")
     write_shell_expression(shell, attrs, system)

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -45,13 +45,13 @@ def nix_shell(
     attrs: List[str],
     cache_directory: Path,
     system: str,
-    nix_flavor: str,
+    build_graph: str,
     run: Optional[str] = None,
     sandbox: bool = False,
 ) -> None:
-    nix_shell = f"{shutil.which(nix_flavor)}-shell"
+    nix_shell = f"{shutil.which(build_graph)}-shell"
     if not nix_shell:
-        raise RuntimeError(f"{nix_flavor} not found in PATH")
+        raise RuntimeError(f"{build_graph} not found in PATH")
 
     shell = cache_directory.joinpath("shell.nix")
     write_shell_expression(shell, attrs, system)
@@ -230,7 +230,7 @@ def nix_build(
     cache_directory: Path,
     system: str,
     allow: AllowedFeatures,
-    nix_flavor: str,
+    build_graph: str,
 ) -> List[Attr]:
     if not attr_names:
         info("Nothing to be built.")
@@ -249,7 +249,7 @@ def nix_build(
     write_shell_expression(build, filtered, system)
 
     command = [
-        nix_flavor,
+        build_graph,
         "build",
         "--extra-experimental-features",
         "nix-command" if allow.url_literals else "nix-command no-url-literals",

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -247,30 +247,21 @@ def nix_build(
     build = cache_directory.joinpath("build.nix")
     write_shell_expression(build, filtered, system)
 
+    nix_cmd = "nix"
     if nom:
-        command = [
-            "nom",
-            "build",
-            "--extra-experimental-features",
-            "nix-command" if allow.url_literals else "nix-command no-url-literals",
-            "--no-link",
-            "--keep-going",
-            "--allow-import-from-derivation"
-            if allow.ifd
-            else "--no-allow-import-from-derivation",
-        ]
-    else:
-        command = [
-            "nix",
-            "--extra-experimental-features",
-            "nix-command" if allow.url_literals else "nix-command no-url-literals",
-            "build",
-            "--no-link",
-            "--keep-going",
-            "--allow-import-from-derivation"
-            if allow.ifd
-            else "--no-allow-import-from-derivation",
-        ]
+        nix_cmd = "nom"
+
+    command = [
+        nix_cmd,
+        "build",
+        "--extra-experimental-features",
+        "nix-command" if allow.url_literals else "nix-command no-url-literals",
+        "--no-link",
+        "--keep-going",
+        "--allow-import-from-derivation"
+        if allow.ifd
+        else "--no-allow-import-from-derivation",
+    ]
 
     if platform == "linux":
         command += [

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -49,7 +49,7 @@ def nix_shell(
     run: Optional[str] = None,
     sandbox: bool = False,
 ) -> None:
-    nix_shell = shutil.which(nix_flavor)
+    nix_shell = f"{shutil.which(nix_flavor)}-shell"
     if not nix_shell:
         raise RuntimeError(f"{nix_flavor} not found in PATH")
 

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -87,7 +87,7 @@ class Review:
         remote: str,
         system: str,
         allow: AllowedFeatures,
-        nom_path: str,
+        nix_flavor: str,
         api_token: Optional[str] = None,
         use_ofborg_eval: Optional[bool] = True,
         only_packages: Set[str] = set(),
@@ -112,7 +112,7 @@ class Review:
         self.system = system
         self.allow = allow
         self.sandbox = sandbox
-        self.nom_path = nom_path
+        self.nix_flavor = nix_flavor
 
     def worktree_dir(self) -> str:
         return str(self.builddir.worktree_dir)
@@ -194,7 +194,7 @@ class Review:
             self.builddir.path,
             self.system,
             self.allow,
-            self.nom_path,
+            self.nix_flavor,
         )
 
     def build_pr(self, pr_number: int) -> List[Attr]:
@@ -254,7 +254,7 @@ class Review:
                 report.built_packages(),
                 path,
                 self.system,
-                self.nom_path,
+                self.nix_flavor,
                 self.run,
                 self.sandbox,
             )
@@ -505,7 +505,7 @@ def review_local_revision(
             package_regexes=args.package_regex,
             system=args.system,
             allow=allow,
-            nom_path=args.nom_path,
+            nix_flavor=args.nix_flavor,
         )
         review.review_commit(builddir.path, args.branch, commit, staged)
         return builddir.path

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -87,7 +87,7 @@ class Review:
         remote: str,
         system: str,
         allow: AllowedFeatures,
-        nix_flavor: str,
+        build_graph: str,
         api_token: Optional[str] = None,
         use_ofborg_eval: Optional[bool] = True,
         only_packages: Set[str] = set(),
@@ -112,7 +112,7 @@ class Review:
         self.system = system
         self.allow = allow
         self.sandbox = sandbox
-        self.nix_flavor = nix_flavor
+        self.build_graph = build_graph
 
     def worktree_dir(self) -> str:
         return str(self.builddir.worktree_dir)
@@ -194,7 +194,7 @@ class Review:
             self.builddir.path,
             self.system,
             self.allow,
-            self.nix_flavor,
+            self.build_graph,
         )
 
     def build_pr(self, pr_number: int) -> List[Attr]:
@@ -254,7 +254,7 @@ class Review:
                 report.built_packages(),
                 path,
                 self.system,
-                self.nix_flavor,
+                self.build_graph,
                 self.run,
                 self.sandbox,
             )
@@ -505,7 +505,7 @@ def review_local_revision(
             package_regexes=args.package_regex,
             system=args.system,
             allow=allow,
-            nix_flavor=args.nix_flavor,
+            build_graph=args.build_graph,
         )
         review.review_commit(builddir.path, args.branch, commit, staged)
         return builddir.path

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -95,6 +95,7 @@ class Review:
         skip_packages_regex: List[Pattern[str]] = [],
         checkout: CheckoutOption = CheckoutOption.MERGE,
         sandbox: bool = False,
+        nom: bool = False,
     ) -> None:
         self.builddir = builddir
         self.build_args = build_args
@@ -111,6 +112,7 @@ class Review:
         self.system = system
         self.allow = allow
         self.sandbox = sandbox
+        self.nom = nom
 
     def worktree_dir(self) -> str:
         return str(self.builddir.worktree_dir)
@@ -192,6 +194,7 @@ class Review:
             self.builddir.path,
             self.system,
             self.allow,
+            self.nom,
         )
 
     def build_pr(self, pr_number: int) -> List[Attr]:
@@ -497,6 +500,7 @@ def review_local_revision(
             package_regexes=args.package_regex,
             system=args.system,
             allow=allow,
+            nom=args.nom,
         )
         review.review_commit(builddir.path, args.branch, commit, staged)
         return builddir.path

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -87,6 +87,7 @@ class Review:
         remote: str,
         system: str,
         allow: AllowedFeatures,
+        nom_path: str,
         api_token: Optional[str] = None,
         use_ofborg_eval: Optional[bool] = True,
         only_packages: Set[str] = set(),
@@ -95,7 +96,6 @@ class Review:
         skip_packages_regex: List[Pattern[str]] = [],
         checkout: CheckoutOption = CheckoutOption.MERGE,
         sandbox: bool = False,
-        nom: bool = False,
     ) -> None:
         self.builddir = builddir
         self.build_args = build_args
@@ -112,7 +112,7 @@ class Review:
         self.system = system
         self.allow = allow
         self.sandbox = sandbox
-        self.nom = nom
+        self.nom_path = nom_path
 
     def worktree_dir(self) -> str:
         return str(self.builddir.worktree_dir)
@@ -194,7 +194,7 @@ class Review:
             self.builddir.path,
             self.system,
             self.allow,
-            self.nom,
+            self.nom_path,
         )
 
     def build_pr(self, pr_number: int) -> List[Attr]:
@@ -254,9 +254,9 @@ class Review:
                 report.built_packages(),
                 path,
                 self.system,
+                self.nom_path,
                 self.run,
                 self.sandbox,
-                self.nom,
             )
 
     def review_commit(
@@ -505,7 +505,7 @@ def review_local_revision(
             package_regexes=args.package_regex,
             system=args.system,
             allow=allow,
-            nom=args.nom,
+            nom_path=args.nom_path,
         )
         review.review_commit(builddir.path, args.branch, commit, staged)
         return builddir.path

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -251,7 +251,12 @@ class Review:
             sys.exit(0 if report.succeeded() else 1)
         else:
             nix_shell(
-                report.built_packages(), path, self.system, self.run, self.sandbox
+                report.built_packages(),
+                path,
+                self.system,
+                self.run,
+                self.sandbox,
+                self.nom,
             )
 
     def review_commit(

--- a/nixpkgs_review/utils.py
+++ b/nixpkgs_review/utils.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -9,7 +10,7 @@ HAS_TTY = sys.stdout.isatty()
 ROOT = Path(os.path.dirname(os.path.realpath(__file__)))
 
 
-def color_text(code: int, file: IO[Any] = sys.stdout) -> Callable[[str], None]:
+def color_text(code: int, file: Optional[IO[Any]] = None) -> Callable[[str], None]:
     def wrapper(text: str) -> None:
         if HAS_TTY:
             print(f"\x1b[{code}m{text}\x1b[0m", file=file)
@@ -62,3 +63,11 @@ def current_system() -> str:
         text=True,
     )
     return system.stdout
+
+
+def nix_nom_tool() -> str:
+    "Return `nom` if found in $PATH"
+    if not shutil.which("nom"):
+        return "nix"
+    else:
+        return "nom"

--- a/nixpkgs_review/utils.py
+++ b/nixpkgs_review/utils.py
@@ -67,7 +67,7 @@ def current_system() -> str:
 
 def nix_nom_tool() -> str:
     "Return `nom` if found in $PATH"
-    if not shutil.which("nom"):
-        return "nix"
-    else:
+    if shutil.which("nom"):
         return "nom"
+    else:
+        return "nix"

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -34,6 +34,24 @@ def test_pr_local_eval(helpers: Helpers) -> None:
         assert report["built"] == ["pkg1"]
 
 
+@pytest.mark.skipif(not shutil.which("nom"), reason="`nom` not found in PATH")
+def test_pr_local_eval_nom(helpers: Helpers) -> None:
+    with helpers.nixpkgs() as nixpkgs:
+        with open(nixpkgs.path.joinpath("pkg1.txt"), "w") as f:
+            f.write("foo")
+        subprocess.run(["git", "add", "."])
+        subprocess.run(["git", "commit", "-m", "example-change"])
+        subprocess.run(["git", "checkout", "-b", "pull/1/head"])
+        subprocess.run(["git", "push", str(nixpkgs.remote), "pull/1/head"])
+
+        path = main(
+            "nixpkgs-review",
+            ["pr", "--remote", str(nixpkgs.remote), "--run", "exit 0", "1", "--nom"],
+        )
+        report = helpers.load_report(path)
+        assert report["built"] == ["pkg1"]
+
+
 @pytest.mark.skipif(not shutil.which("bwrap"), reason="`bwrap` not found in PATH")
 def test_pr_local_eval_with_sandbox(helpers: Helpers) -> None:
     with helpers.nixpkgs() as nixpkgs:

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -91,7 +91,7 @@ def test_pr_local_eval_without_nom(helpers: Helpers, capfd) -> None:
                 "--run",
                 "exit 0",
                 "1",
-                "--nix-flavor",
+                "--build-graph",
                 "nix",
             ],
         )

--- a/tests/test_rev.py
+++ b/tests/test_rev.py
@@ -39,7 +39,7 @@ def test_rev_command_without_nom(helpers: Helpers) -> None:
                 str(nixpkgs.remote),
                 "--run",
                 "exit 0",
-                "--nix-flavor",
+                "--build-graph",
                 "nix",
             ],
         )

--- a/tests/test_rev.py
+++ b/tests/test_rev.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import pytest
+import shutil
 import subprocess
 
 from nixpkgs_review.cli import main
@@ -16,6 +18,29 @@ def test_rev_command(helpers: Helpers) -> None:
         path = main(
             "nixpkgs-review",
             ["rev", "HEAD", "--remote", str(nixpkgs.remote), "--run", "exit 0"],
+        )
+        report = helpers.load_report(path)
+        assert report["built"] == ["pkg1"]
+
+
+@pytest.mark.skipif(not shutil.which("nom"), reason="`nom` not found in PATH")
+def test_rev_command_with_nom(helpers: Helpers) -> None:
+    with helpers.nixpkgs() as nixpkgs:
+        with open(nixpkgs.path.joinpath("pkg1.txt"), "w") as f:
+            f.write("foo")
+        subprocess.run(["git", "add", "."])
+        subprocess.run(["git", "commit", "-m", "example-change"])
+        path = main(
+            "nixpkgs-review",
+            [
+                "rev",
+                "HEAD",
+                "--remote",
+                str(nixpkgs.remote),
+                "--run",
+                "exit 0",
+                "--nom",
+            ],
         )
         report = helpers.load_report(path)
         assert report["built"] == ["pkg1"]

--- a/tests/test_rev.py
+++ b/tests/test_rev.py
@@ -9,6 +9,7 @@ from nixpkgs_review.cli import main
 from .conftest import Helpers
 
 
+@pytest.mark.skipif(not shutil.which("nom"), reason="`nom` not found in PATH")
 def test_rev_command(helpers: Helpers) -> None:
     with helpers.nixpkgs() as nixpkgs:
         with open(nixpkgs.path.joinpath("pkg1.txt"), "w") as f:
@@ -23,8 +24,7 @@ def test_rev_command(helpers: Helpers) -> None:
         assert report["built"] == ["pkg1"]
 
 
-@pytest.mark.skipif(not shutil.which("nom"), reason="`nom` not found in PATH")
-def test_rev_command_with_nom(helpers: Helpers) -> None:
+def test_rev_command_without_nom(helpers: Helpers) -> None:
     with helpers.nixpkgs() as nixpkgs:
         with open(nixpkgs.path.joinpath("pkg1.txt"), "w") as f:
             f.write("foo")
@@ -39,7 +39,8 @@ def test_rev_command_with_nom(helpers: Helpers) -> None:
                 str(nixpkgs.remote),
                 "--run",
                 "exit 0",
-                "--nom",
+                "--nom-path",
+                "",
             ],
         )
         report = helpers.load_report(path)

--- a/tests/test_rev.py
+++ b/tests/test_rev.py
@@ -39,8 +39,8 @@ def test_rev_command_without_nom(helpers: Helpers) -> None:
                 str(nixpkgs.remote),
                 "--run",
                 "exit 0",
-                "--nom-path",
-                "",
+                "--nix-flavor",
+                "nix",
             ],
         )
         report = helpers.load_report(path)

--- a/tests/test_wip.py
+++ b/tests/test_wip.py
@@ -7,6 +7,7 @@ from nixpkgs_review.cli import main
 from .conftest import Helpers
 
 
+@pytest.mark.skipif(not shutil.which("nom"), reason="`nom` not found in PATH")
 def test_wip_command(helpers: Helpers) -> None:
     with helpers.nixpkgs() as nixpkgs:
         with open(nixpkgs.path.joinpath("pkg1.txt"), "w") as f:
@@ -19,14 +20,21 @@ def test_wip_command(helpers: Helpers) -> None:
         assert report["built"] == ["pkg1"]
 
 
-@pytest.mark.skipif(not shutil.which("nom"), reason="`nom` not found in PATH")
-def test_wip_command_nom(helpers: Helpers) -> None:
+def test_wip_command_without_nom(helpers: Helpers) -> None:
     with helpers.nixpkgs() as nixpkgs:
         with open(nixpkgs.path.joinpath("pkg1.txt"), "w") as f:
             f.write("foo")
         path = main(
             "nixpkgs-review",
-            ["wip", "--remote", str(nixpkgs.remote), "--run", "exit 0", "--nom"],
+            [
+                "wip",
+                "--remote",
+                str(nixpkgs.remote),
+                "--run",
+                "exit 0",
+                "--nom-path",
+                "",
+            ],
         )
         report = helpers.load_report(path)
         assert report["built"] == ["pkg1"]

--- a/tests/test_wip.py
+++ b/tests/test_wip.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import pytest
+import shutil
 from nixpkgs_review.cli import main
 
 from .conftest import Helpers
@@ -12,6 +14,19 @@ def test_wip_command(helpers: Helpers) -> None:
         path = main(
             "nixpkgs-review",
             ["wip", "--remote", str(nixpkgs.remote), "--run", "exit 0"],
+        )
+        report = helpers.load_report(path)
+        assert report["built"] == ["pkg1"]
+
+
+@pytest.mark.skipif(not shutil.which("nom"), reason="`nom` not found in PATH")
+def test_wip_command_nom(helpers: Helpers) -> None:
+    with helpers.nixpkgs() as nixpkgs:
+        with open(nixpkgs.path.joinpath("pkg1.txt"), "w") as f:
+            f.write("foo")
+        path = main(
+            "nixpkgs-review",
+            ["wip", "--remote", str(nixpkgs.remote), "--run", "exit 0", "--nom"],
         )
         report = helpers.load_report(path)
         assert report["built"] == ["pkg1"]

--- a/tests/test_wip.py
+++ b/tests/test_wip.py
@@ -8,7 +8,7 @@ from .conftest import Helpers
 
 
 @pytest.mark.skipif(not shutil.which("nom"), reason="`nom` not found in PATH")
-def test_wip_command(helpers: Helpers) -> None:
+def test_wip_command(helpers: Helpers, capfd) -> None:
     with helpers.nixpkgs() as nixpkgs:
         with open(nixpkgs.path.joinpath("pkg1.txt"), "w") as f:
             f.write("foo")
@@ -18,9 +18,11 @@ def test_wip_command(helpers: Helpers) -> None:
         )
         report = helpers.load_report(path)
         assert report["built"] == ["pkg1"]
+        captured = capfd.readouterr()
+        assert "$ nom build" in captured.out
 
 
-def test_wip_command_without_nom(helpers: Helpers) -> None:
+def test_wip_command_without_nom(helpers: Helpers, capfd) -> None:
     with helpers.nixpkgs() as nixpkgs:
         with open(nixpkgs.path.joinpath("pkg1.txt"), "w") as f:
             f.write("foo")
@@ -32,9 +34,11 @@ def test_wip_command_without_nom(helpers: Helpers) -> None:
                 str(nixpkgs.remote),
                 "--run",
                 "exit 0",
-                "--nom-path",
-                "",
+                "--nix-flavor",
+                "nix",
             ],
         )
         report = helpers.load_report(path)
         assert report["built"] == ["pkg1"]
+        captured = capfd.readouterr()
+        assert "$ nix build" in captured.out

--- a/tests/test_wip.py
+++ b/tests/test_wip.py
@@ -34,7 +34,7 @@ def test_wip_command_without_nom(helpers: Helpers, capfd) -> None:
                 str(nixpkgs.remote),
                 "--run",
                 "exit 0",
-                "--nix-flavor",
+                "--build-graph",
                 "nix",
             ],
         )


### PR DESCRIPTION
`nix-output-monitor` provides a nice real time build graph, which gives more information about what builds where, which is especially nice for larger rebuilds.

fixes #302