### PR TITLE
build and symlink each output of the packages

### DIFF
--- a/nixpkgs_review/nix/evalAttrs.nix
+++ b/nixpkgs_review/nix/evalAttrs.nix
@@ -3,22 +3,39 @@
 with builtins;
 let
   pkgs = import <nixpkgs> { config = { checkMeta = true; allowUnfree = true; inherit allowAliases; }; };
-  lib = pkgs.lib;
+  inherit (pkgs) lib;
 
   attrs = fromJSON (readFile attr-json);
-  getProperties = name: let
-    attrPath = lib.splitString "." name;
-    pkg = lib.attrByPath attrPath null pkgs;
-    # some packages are set to null if they aren't compatible with a platform or package set
-    maybePath = if pkg == null then
-        { success = false; value = null; }
-      else
-        builtins.tryEval "${pkg}";
-  in rec {
-    exists = lib.hasAttrByPath attrPath pkgs;
-    broken = !exists || !maybePath.success;
-    path = if !broken then maybePath.value else null;
-    drvPath = if !broken then pkg.drvPath else null;
-  };
+  getProperties = name:
+    let
+      attrPath = lib.splitString "." name;
+      pkg = lib.attrByPath attrPath null pkgs;
+      exists = lib.hasAttrByPath attrPath pkgs;
+    in
+    if pkg == null then
+      [
+        (lib.nameValuePair name {
+          inherit exists;
+          broken = true;
+          path = null;
+          drvPath = null;
+        })
+      ]
+    else
+      lib.flip map pkg.outputs or [ "out" ] (output:
+        let
+          # some packages are set to null if they aren't compatible with a platform or package set
+          maybePath = tryEval "${lib.getOutput output pkg}";
+          broken = !exists || !maybePath.success;
+        in
+        lib.nameValuePair
+          (if output == "out" then name else "${name}.${output}")
+          {
+            inherit exists broken;
+            path = if !broken then maybePath.value else null;
+            drvPath = if !broken then pkg.drvPath else null;
+          }
+      );
 in
-  pkgs.lib.genAttrs attrs getProperties
+
+listToAttrs (concatMap getProperties attrs)


### PR DESCRIPTION
fixes #306

the output paths will be similar to the regular nix `result`s, the following results are tested with https://github.com/NixOS/nixpkgs/pull/215728

```console
4 packages built:
geogram geogram.bin geogram.dev geogram.lib

$ tree results
results
├── geogram -> /nix/store/jd1ys0jn7sp9bw647ch8ydp5ic3l09g6-geogram-1.8.2
├── geogram.bin -> /nix/store/j64i56kvgg5wp5m1snhxwmm9wcbg2zm1-geogram-1.8.2-bin
├── geogram.dev -> /nix/store/cr6wlvc22gj072r0fw0j52kbmqmpr6my-geogram-1.8.2-dev
└── geogram.lib -> /nix/store/299za097p633g4w1ig63g8k5zcf86nk6-geogram-1.8.2-lib

```