### PR TITLE
fix gist url calculation

### DIFF
--- a/nixpkgs_review/github.py
+++ b/nixpkgs_review/github.py
@@ -84,8 +84,9 @@ class GithubClient:
                     return packages_per_system
 
                 url = urllib.parse.urlparse(url)
+                gist_hash = url.path.split("/")[-1]
                 raw_gist_url = (
-                    f"https://gist.githubusercontent.com/GrahamcOfBorg{url.path}/raw/"
+                    f"https://gist.githubusercontent.com/GrahamcOfBorg/{gist_hash}/raw/"
                 )
                 for line in urllib.request.urlopen(raw_gist_url):
                     if line == b"":


### PR DESCRIPTION
closes #321 

There was likely an update in github's gist api that added the username to the returned url, which makes the previous logic not work with the new ofborg gist urls
