### PR TITLE
avoid `nix log` warning

### DIFF
--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -67,7 +67,7 @@ def write_error_logs(attrs: List[Attr], directory: Path) -> None:
                 symlink_source.unlink()
             symlink_source.symlink_to(attr.path)
 
-        for path in [attr.drv_path, attr.path]:
+        for path in [f"{attr.drv_path}^*", attr.path]:
             if not path:
                 continue
             with open(logs.ensure().joinpath(attr.name + ".log"), "w+") as f:


### PR DESCRIPTION
```
warning: The interpretation of store paths arguments ending in `.drv` recently changed. If this command is now failing try again with '...^*'
```