### PR TITLE
utils/escape_attr: enclose with quotes all elements but the first + tests

### DIFF
--- a/nixpkgs_review/utils.py
+++ b/nixpkgs_review/utils.py
@@ -39,10 +39,10 @@ def verify_commit_hash(commit: str) -> str:
 
 
 def escape_attr(attr: str) -> str:
-    index = attr.rfind(".")
-    if index == -1:
-        return attr
-    return f'{attr[:index]}."{attr[index+1:]}"'
+    attr_parts = attr.split(".")
+    first = attr_parts[0]
+    rest = [f'"{item}"' for item in attr_parts[1:]]
+    return ".".join([first, *rest])
 
 
 @functools.lru_cache(maxsize=1)

--- a/tests/test_escape_attr.py
+++ b/tests/test_escape_attr.py
@@ -1,0 +1,7 @@
+from nixpkgs_review.utils import escape_attr
+
+
+def test_escape_attr() -> None:
+    assert escape_attr("hello") == "hello"
+    assert escape_attr("haskellPackages.if") == 'haskellPackages."if"'
+    assert escape_attr("haskellPackages.if.doc") == 'haskellPackages."if"."doc"'


### PR DESCRIPTION
I found a lexing issue in nix when running nixpkgs-review for https://github.com/NixOS/nixpkgs/pull/247099. 

It generated a line like `haskelPackages.if` and Nix confused it with a if statement.

I also added tests to check compliance.