### PR TITLE
don't rely on `NIX_PATH`

### DIFF
--- a/nixpkgs_review/builddir.py
+++ b/nixpkgs_review/builddir.py
@@ -58,7 +58,10 @@ class Builddir:
 
         self.worktree_dir = self.path.joinpath("nixpkgs")
         self.worktree_dir.mkdir()
-        nix_path = ["nixpkgs={self.worktree_dir}", "nixpkgs-overlays={self.overlay.path}"]
+        nix_path = [
+            f"nixpkgs={self.worktree_dir}",
+            f"nixpkgs-overlays={self.overlay.path}",
+        ]
         # we don't actually use this, but its handy for users who want to try out things with the current nixpkgs version.
         os.environ["NIX_PATH"] = ":".join(nix_path)
         self.nix_path = " ".join(nix_path)

--- a/nixpkgs_review/builddir.py
+++ b/nixpkgs_review/builddir.py
@@ -66,10 +66,6 @@ class Builddir:
         os.environ["NIX_PATH"] = ":".join(nix_path)
         self.nix_path = " ".join(nix_path)
 
-        self.nix_path = (
-            f"nixpkgs={self.worktree_dir} nixpkgs-overlays={self.overlay.path}"
-        )
-
     def __enter__(self) -> "Builddir":
         return self
 

--- a/nixpkgs_review/builddir.py
+++ b/nixpkgs_review/builddir.py
@@ -58,6 +58,10 @@ class Builddir:
 
         self.worktree_dir = self.path.joinpath("nixpkgs")
         self.worktree_dir.mkdir()
+        nix_path = ["nixpkgs={self.worktree_dir}", "nixpkgs-overlays={self.overlay.path}"]
+        # we don't actually use this, but its handy for users who want to try out things with the current nixpkgs version.
+        os.environ["NIX_PATH"] = ":".join(nix_path)
+        self.nix_path = " ".join(nix_path)
 
         self.nix_path = (
             f"nixpkgs={self.worktree_dir} nixpkgs-overlays={self.overlay.path}"

--- a/nixpkgs_review/builddir.py
+++ b/nixpkgs_review/builddir.py
@@ -58,12 +58,10 @@ class Builddir:
 
         self.worktree_dir = self.path.joinpath("nixpkgs")
         self.worktree_dir.mkdir()
-        self.worktree_dir = self.worktree_dir
 
-        os.environ["NIX_PATH"] = self.nixpkgs_path()
-
-    def nixpkgs_path(self) -> str:
-        return f"nixpkgs={self.worktree_dir}:nixpkgs-overlays={self.overlay.path}"
+        self.nix_path = (
+            f"nixpkgs={self.worktree_dir} nixpkgs-overlays={self.overlay.path}"
+        )
 
     def __enter__(self) -> "Builddir":
         return self

--- a/nixpkgs_review/cli/post_result.py
+++ b/nixpkgs_review/cli/post_result.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import subprocess
 import sys
 from pathlib import Path
 
@@ -17,14 +16,7 @@ def post_result_command(args: argparse.Namespace) -> None:
         sys.exit(1)
     pr = int(pr_env)
 
-    output = subprocess.run(
-        ["nix-instantiate", "--find-file", "nixpkgs"],
-        check=True,
-        stdout=subprocess.PIPE,
-        text=True,
-    ).stdout.strip()
-    nixpkgs_path = Path(output)
-    report = nixpkgs_path.parent.joinpath("report.md")
+    report = Path(os.environ["NIXPKGS_REVIEW_ROOT"]) / "report.md"
     if not report.exists():
         warn(f"Report not found in {report}. Are you in a nixpkgs-review nix-shell?")
         sys.exit(1)

--- a/tests/test_github_actions.py
+++ b/tests/test_github_actions.py
@@ -9,12 +9,14 @@ from .conftest import Helpers
 @patch("urllib.request.urlopen")
 def test_post_result(mock_urlopen: MagicMock, helpers: Helpers) -> None:
     with helpers.nixpkgs() as nixpkgs:
+        root = nixpkgs.path.parent
+
         os.environ["PR"] = "1"
-        os.environ["NIX_PATH"] = f"nixpkgs={nixpkgs.path}"
         os.environ["GITHUB_TOKEN"] = "foo"
+        os.environ["NIXPKGS_REVIEW_ROOT"] = str(root)
         mock_urlopen.side_effect = [mock_open(read_data="{}")()]
 
-        report = nixpkgs.path.joinpath("..", "report.md")
+        report = root / "report.md"
         with open(report, "w") as f:
             f.write("")
 


### PR DESCRIPTION
Nix does not respect `NIX_PATH` when the `nix-path` setting in nix.conf
is set, which breaks the `nix-store --verify-path` due to `<nixpkgs>`
diverging from the temporary nixpkgs created by nixpkgs-review.

fixes #343