### PR TITLE
allow access to the nixpkgs overlay in the sandbox

### DIFF
--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -277,6 +277,7 @@ class Review:
                 self.build_graph,
                 self.builddir.nix_path,
                 self.nixpkgs_config,
+                self.builddir.overlay.path,
                 self.run,
                 self.sandbox,
             )


### PR DESCRIPTION
fixes this warning

```
warning: Nix search path entry '/tmp/tmpXXXXXXXX' does not exist, ignoring
```