### PR TITLE
fix "error: cannot find flake 'flake:None' in the flake registries"

### DIFF
--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -55,7 +55,8 @@ def write_error_logs(attrs: list[Attr], directory: Path) -> None:
     results = LazyDirectory(directory.joinpath("results"))
     failed_results = LazyDirectory(directory.joinpath("failed_results"))
     for attr in attrs:
-        if attr.blacklisted:
+        # Broken attrs have no drv_path.
+        if attr.blacklisted or attr.drv_path is None:
             continue
 
         if attr.path is not None and os.path.exists(attr.path):


### PR DESCRIPTION
Culprit found with:

```
python -m trace --ignore-dir "$(python -c 'import os, sys; print(os.pathsep.join(sys.path[1:]))')" -t $NIXGITS/nixpkgs-review/result/bin/.nixpkgs-review-wrapped pr 261631
```

from the comments of https://stackoverflow.com/a/33449763.

`nix log` had `None^*` as the path.

Closes https://github.com/Mic92/nixpkgs-review/issues/354