### PR TITLE
Make the `review-shell` purer

### DIFF
--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -300,22 +300,23 @@ def write_shell_expression(
     with open(filename, "w+", encoding="utf-8") as f:
         f.write(
             f"""{{ pkgs ? import ./nixpkgs {{ system = \"{system}\"; config = import {nixpkgs_config}; }} }}:
-with pkgs;
+
 let
-  paths = [
+  paths = with pkgs; [
 """
         )
         f.write("\n".join(f"    {escape_attr(a)}" for a in attrs))
         f.write(
             """
   ];
-  env = buildEnv {
+  hostPkgs = (import ./nixpkgs { });
+  env = hostPkgs.buildEnv {
     name = "env";
     inherit paths;
     pathsToLink = [ "/bin" ];
     ignoreCollisions = true;
   };
-in (import ./nixpkgs { }).mkShell {
+in hostPkgs.mkShell {
   name = "review-shell";
   preferLocalBuild = true;
   allowSubstitutes = false;

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -312,6 +312,7 @@ let
   env = buildEnv {
     name = "env";
     inherit paths;
+    pathsToLink = [ "/bin" ];
     ignoreCollisions = true;
   };
 in (import ./nixpkgs { }).mkShell {

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -320,7 +320,8 @@ in (import ./nixpkgs { }).mkShell {
   preferLocalBuild = true;
   allowSubstitutes = false;
   dontWrapQtApps = true;
-  packages = if builtins.length paths > 50 then [ env ] else paths;
+  # with a separate buildEnv the impurities such as hooks and propagatedBuildInputs won't be added to the shell
+  packages = [ env ];
 }
 """
         )


### PR DESCRIPTION
The only purpose of this `env` (I assume) is to add the binaries to the `PATH`.

The benefit of making it purer is that unwrapped programs missing dependencies may fail.

As a added benefit this dramatically reduces the collision warnings from `buildEnv`

`warning: collision between '/nix/store/82icynaidvzyic2g349cqi4p9a5d4aa2-vimplugin-ai.vim-2023-10-03/doc/tags' and '/nix/store/qc4bdwi6zhk4r1vzbcxrnwrrjnm33a6g-vimplugin-CheckAttach-2019-05-08/doc/tags'`

Closes https://github.com/Mic92/nixpkgs-review/issues/370