### PR TITLE
nix: make review-shell.nix code static

### DIFF
--- a/nixpkgs_review/nix/review-shell.nix
+++ b/nixpkgs_review/nix/review-shell.nix
@@ -1,0 +1,23 @@
+{ system
+, nixpkgs-config-path # Path to Nix file containing the Nixpkgs config
+, attrs-path # Path to Nix file containing a list of attributes to build
+, nixpkgs-path # Path to this review's nixpkgs
+, pkgs ? import nixpkgs-path { inherit system; config = import nixpkgs-config-path; }
+, lib ? pkgs.lib
+}:
+
+let
+  attrs = import attrs-path pkgs;
+  env = pkgs.buildEnv {
+    name = "env";
+    paths = attrs;
+    ignoreCollisions = true;
+  };
+in
+(import nixpkgs-path { }).mkShell {
+  name = "review-shell";
+  preferLocalBuild = true;
+  allowSubstitutes = false;
+  dontWrapQtApps = true;
+  packages = if builtins.length attrs > 50 then [ env ] else attrs;
+}


### PR DESCRIPTION
Previously, the whole shell.nix was created at runtime using string substitution and other crimes that made it hard to work on the expression itself.

This patch turns the string substitutions into Nix function arguments to an otherwise static Nix expression and only generates the list of attrs to be built dynamically.