### PR TITLE
always use the buildEnv

### DIFF
--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -118,7 +118,6 @@ class ShellConfig:
     nixpkgs_overlay: Path
     run: str | None = None
     sandbox: bool = False
-    pkgs: str | None = None
     options: tuple[tuple[str, str], ...] = ()
 
 
@@ -137,7 +136,6 @@ def nix_shell(
         attrs_per_system=attrs_per_system,
         local_system=config.local_system,
         nixpkgs_config=config.nixpkgs_config,
-        pkgs=config.pkgs,
     )
     if config.sandbox:
         with TemporaryDirectory(prefix="nixpkgs-review-links-") as dirname:
@@ -427,7 +425,6 @@ def nix_build(
         attrs_per_system=filtered_per_system,
         local_system=build_config.local_system,
         nixpkgs_config=build_config.nixpkgs_config,
-        pkgs=build_config.pkgs,
     )
     _write_review_shell_drv(
         cache_directory=cache_directory,
@@ -446,7 +443,6 @@ def build_shell_file_args(
     attrs_per_system: dict[System, list[str]],
     local_system: str,
     nixpkgs_config: Path,
-    pkgs: str | None = None,
 ) -> list[str]:
     attrs_file = cache_dir.joinpath("attrs.nix")
     with attrs_file.open("w+") as f:
@@ -471,7 +467,6 @@ def build_shell_file_args(
         "--argstr",
         "attrs-path",
         str(attrs_file),
-        *(["--argstr", "alt-pkgs", pkgs] if pkgs else []),
     ]
 
 

--- a/nixpkgs_review/nix/review-shell.nix
+++ b/nixpkgs_review/nix/review-shell.nix
@@ -6,8 +6,6 @@
   # Path to Nix file containing a list of attributes to build
   nixpkgs-path,
   # Path to this review's nixpkgs
-  alt-pkgs ? null,
-  # Alternative package set name (e.g. pkgsCross.aarch64-multiplatform), or null for default
   local-pkgs ? import nixpkgs-path {
     system = local-system;
     config = import nixpkgs-config-path;
@@ -35,27 +33,28 @@ let
     ) system-attrs;
   attrs = lib.flatten (lib.mapAttrsToList extractPackagesForSystem (import attrs-path));
   supportIgnoreSingleFileOutputs = (lib.functionArgs local-pkgs.buildEnv) ? ignoreSingleFileOutputs;
+  # Always go through buildEnv rather than putting attrs into mkShell directly:
+  # - only bin/ ends up on PATH, so setup hooks and propagated inputs of the
+  #   reviewed packages don't leak into the shell and mask missing runtime
+  #   dependencies of unwrapped programs,
+  # - nixpkgs' platform filtering on nativeBuildInputs would otherwise
+  #   silently drop cross/foreign-system packages.
   env = local-pkgs.buildEnv (
     {
       name = "env";
       paths = attrs;
+      pathsToLink = [ "/bin" ];
       ignoreCollisions = true;
     }
     // lib.optionalAttrs supportIgnoreSingleFileOutputs {
       ignoreSingleFileOutputs = true;
     }
   );
-  # When using an alternative package set (cross, musl, static, cuda…),
-  # always wrap in buildEnv to avoid nixpkgs platform filtering on nativeBuildInputs
-  # which would silently drop cross-compiled packages from the dependency graph.
-  # Otherwise, use the buildEnv threshold of 50 to preserve setup hooks in the shell.
-  useEnv = alt-pkgs != null || builtins.length attrs > 50;
 in
 (import nixpkgs-path { }).mkShell {
   name = "review-shell";
   preferLocalBuild = true;
   allowSubstitutes = false;
   dontWrapQtApps = true;
-  # see test_rev_command_with_pkg_count
-  packages = if useEnv then [ env ] else attrs;
+  packages = [ env ];
 }

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -690,7 +690,6 @@ class Review:
                 nixpkgs_overlay=self.builddir.overlay.path,
                 run=self.shell_options.run,
                 sandbox=self.shell_options.sandbox,
-                pkgs=self.build_config.pkgs,
                 options=self.build_config.options,
             )
             nix_shell(report.built_packages(), shell_config)


### PR DESCRIPTION
The purpose of this `env` is to add the binaries to the `PATH`.

The benefit of making it purer is that unwrapped programs missing dependencies may fail.

As a added benefit this dramatically reduces the collision warnings from `buildEnv`

based on https://github.com/Mic92/nixpkgs-review/pull/373