### PR TITLE
argcomplete: fix auto-generated shell-completions in postInstall

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -48,9 +48,9 @@ python3.pkgs.buildPythonApplication {
   postInstall = lib.optionalString withAutocomplete ''
     for cmd in nix-review nixpkgs-review; do
       installShellCompletion --cmd $cmd \
-        --bash <(register-python-argcomplete $out/bin/$cmd) \
-        --fish <(register-python-argcomplete $out/bin/$cmd -s fish) \
-        --zsh <(register-python-argcomplete $out/bin/$cmd -s zsh)
+        --bash <(register-python-argcomplete $cmd) \
+        --fish <(register-python-argcomplete $cmd -s fish) \
+        --zsh <(register-python-argcomplete $cmd -s zsh)
     done
   '';
 


### PR DESCRIPTION
Result after this change (zsh, but tested in bash and also makes them work but less nice but also unconfigured bash compared to personal zsh-setup):
![Screenshot from 2024-03-16 21-55-10](https://github.com/Mic92/nixpkgs-review/assets/17243347/3b1b68ac-3348-4cbc-bf3d-d09fb458e734)
![Screenshot from 2024-03-16 21-55-21](https://github.com/Mic92/nixpkgs-review/assets/17243347/fb95cfa2-177d-491f-90a8-1d077e858d83)

I wen the wrong way first and tried to setup/make argcomplete global-setup work with NixOS/wrappers by resolving the last line and redirecting the resolution but later figured out that's not needed.

I looked through nixpkgs and only found one other package using the full path (https://github.com/search?q=repo%3ANixOS%2Fnixpkgs+register-python-argcomplete+%24out&type=code) and enabling `_ARC_DEBUG` made me realize the registered completion does not trigger as it never (except you copy the full path to nix-store) matches.

If this is accepted I can also provide a nixpkgs-pr with reference to here ✌🏻 