### PR TITLE
Add flag to build package `passthru.tests`

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,10 @@ attribute set:
 $ nixpkgs-review pr -p nixosTests.ferm 47077
 ```
 
+Many packages also specify their associated `nixosTests` in the `tests`
+attribute set. Adding the `--tests` argument will run those tests for all
+packages that will be rebuild.
+
 ## Ignoring ofborg evaluations
 
 By default, nixpkgs-review will use ofborg's evaluation result if available to

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -237,6 +237,11 @@ def common_flags() -> list[CommonFlag]:
             help="Regular expression that package attributes have to match (can be passed multiple times)",
         ),
         CommonFlag(
+            "--tests",
+            action="store_true",
+            help="For all packages to be built, also build their associated `tests`",
+        ),
+        CommonFlag(
             "-r",
             "--remote",
             default="https://github.com/NixOS/nixpkgs",

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -115,7 +115,11 @@ def pr_command(args: argparse.Namespace) -> str:
                     builddir=builddir,
                     package_filter=package_filter_from_args(args),
                     build_config=build_config_from_args(
-                        args, allow, builddir.nix_path, nixpkgs_config
+                        args,
+                        allow,
+                        builddir.nix_path,
+                        nixpkgs_config,
+                        include_tests=args.tests,
                     ),
                     review_config=ReviewConfig(
                         remote=args.remote,

--- a/nixpkgs_review/cli/rev.py
+++ b/nixpkgs_review/cli/rev.py
@@ -27,7 +27,13 @@ def rev_command(args: argparse.Namespace) -> Path:
         return review_local_revision(
             f"rev-{commit}",
             args,
-            partial(build_config_from_args, args, allow, nixpkgs_config=nixpkgs_config),
+            partial(
+                build_config_from_args,
+                args,
+                allow,
+                nixpkgs_config=nixpkgs_config,
+                include_tests=args.tests,
+            ),
             LocalRevisionTarget(
                 commit=commit,
                 action=ReviewAction(print_result=args.print_result),

--- a/nixpkgs_review/cli/wip.py
+++ b/nixpkgs_review/cli/wip.py
@@ -26,7 +26,13 @@ def wip_command(args: argparse.Namespace) -> Path:
         return review_local_revision(
             f"rev-{git.verify_commit_hash('HEAD')}-dirty",
             args,
-            partial(build_config_from_args, args, allow, nixpkgs_config=nixpkgs_config),
+            partial(
+                build_config_from_args,
+                args,
+                allow,
+                nixpkgs_config=nixpkgs_config,
+                include_tests=args.tests,
+            ),
             LocalRevisionTarget(
                 staged=args.staged,
                 action=ReviewAction(print_result=args.print_result),

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -24,7 +24,6 @@ class BuildConfig:
 
     allow: AllowedFeatures
     nix_path: str
-    local_system: str
     nixpkgs_config: Path
     num_eval_workers: int = 1
     max_memory_size: int = 4096
@@ -99,17 +98,14 @@ class ShellConfig:
     """Configuration for launching a nix-shell."""
 
     cache_directory: Path
-    local_system: str
     build_graph: str
     nix_path: str
-    nixpkgs_config: Path
-    nixpkgs_overlay: Path
     run: str | None = None
     sandbox: bool = False
 
 
 def nix_shell(
-    attrs_per_system: dict[System, list[str]],
+    attrs_per_system: dict[System, list[Attr]],
     config: ShellConfig,
 ) -> None:
     bin_name = f"{config.build_graph}-shell"
@@ -121,8 +117,6 @@ def nix_shell(
     shell_file_args = build_shell_file_args(
         cache_dir=config.cache_directory,
         attrs_per_system=attrs_per_system,
-        local_system=config.local_system,
-        nixpkgs_config=config.nixpkgs_config,
     )
     if config.sandbox:
         args = _nix_shell_sandbox(nix_shell_bin, shell_file_args, config)
@@ -200,9 +194,6 @@ def _nix_shell_sandbox(
         *bind("/"),
         *bind("/dev", dev=True),
         *tmpfs("/tmp"),  # noqa: S108
-        # Required for evaluation
-        *bind(config.nixpkgs_config),
-        *bind(config.nixpkgs_overlay),
         # /run (also cover sockets for wayland/pulseaudio and pipewires)
         *bind(Path("/run/user").joinpath(uid), dev=True, try_=True),
         # HOME
@@ -295,6 +286,8 @@ def _nix_eval_filter(packages: NixEvalResult) -> list[Attr]:
 def multi_system_eval(
     attr_names_per_system: dict[System, set[str]],
     build_config: BuildConfig,
+    *,
+    instantiate: bool = False,
 ) -> dict[System, list[Attr]]:
     attr_json = NamedTemporaryFile(mode="w+", delete=False)  # noqa: SIM115
     delete = True
@@ -311,7 +304,7 @@ def multi_system_eval(
             str(build_config.num_eval_workers),
             "--max-memory-size",
             str(build_config.max_memory_size),
-            "--no-instantiate",
+            *(() if instantiate else ("--no-instantiate",)),
             *_nix_common_flags(build_config.allow, build_config.nix_path),
             "--expr",
             f"(import {eval_script} {{ attr-json = {attr_json.name}; }})",
@@ -369,24 +362,26 @@ def nix_build(
     attrs_per_system: dict[System, list[Attr]] = multi_system_eval(
         attr_names_per_system,
         build_config,
+        instantiate=True,
     )
 
-    filtered_per_system = {
-        system: [attr.name for attr in attrs if not (attr.broken or attr.blacklisted)]
-        for system, attrs in attrs_per_system.items()
-    }
+    filtered_drv_paths = [
+        f"{attr.drv_path}^*"
+        for attrs in attrs_per_system.values()
+        for attr in attrs
+        if not (attr.broken or attr.blacklisted)
+    ]
 
-    if all(len(filtered) == 0 for filtered in filtered_per_system.values()):
+    if len(filtered_drv_paths) == 0:
         return attrs_per_system
 
     command = [
         build_graph,
         "build",
-        "--file",
-        REVIEW_SHELL,
         *_nix_common_flags(build_config.allow, build_config.nix_path),
         "--no-link",
         "--keep-going",
+        "--stdin",
     ]
 
     if platform == "linux":
@@ -397,88 +392,37 @@ def nix_build(
             "relaxed",
         ]
 
-    shell_file_args = build_shell_file_args(
-        cache_dir=cache_directory,
-        attrs_per_system=filtered_per_system,
-        local_system=build_config.local_system,
-        nixpkgs_config=build_config.nixpkgs_config,
-    )
-    _write_review_shell_drv(
-        cache_directory=cache_directory,
-        shell_file_args=shell_file_args,
-        allow=build_config.allow,
-        nix_path=build_config.nix_path,
-    )
+    command += shlex.split(args)
 
-    command += shell_file_args + shlex.split(args)
+    rebuilds_file = cache_directory / "rebuilds.txt"
+    with rebuilds_file.open("w+") as f:
+        f.write("".join(f"{p}\n" for p in filtered_drv_paths))
+        f.flush()
+        f.seek(0, os.SEEK_SET)
 
-    sh(command)
+        sh(command, stdin=f)
+
     return attrs_per_system
 
 
 def build_shell_file_args(
     cache_dir: Path,
-    attrs_per_system: dict[System, list[str]],
-    local_system: str,
-    nixpkgs_config: Path,
+    attrs_per_system: dict[System, list[Attr]],
 ) -> list[str]:
-    attrs_file = cache_dir.joinpath("attrs.nix")
-    with attrs_file.open("w+") as f:
-        f.write("{\n")
-        for system, attrs in attrs_per_system.items():
-            f.write(f"  {system} = [\n")
-            for attr in attrs:
-                f.write(f'    "{attr}"\n')
-            f.write("  ];\n")
-        f.write("}")
+    outputs_file = cache_dir.joinpath("outputs.json")
+    with outputs_file.open("w+") as f:
+        json.dump(
+            [
+                str(output)
+                for attrs in attrs_per_system.values()
+                for attr in attrs
+                for output in (attr.outputs or {}).values()
+            ],
+            f,
+        )
 
     return [
         "--argstr",
-        "local-system",
-        local_system,
-        "--argstr",
-        "nixpkgs-path",
-        str(cache_dir.joinpath("nixpkgs/")),
-        "--argstr",
-        "nixpkgs-config-path",
-        str(nixpkgs_config),
-        "--argstr",
-        "attrs-path",
-        str(attrs_file),
+        "outputs-path",
+        str(outputs_file),
     ]
-
-
-def _write_review_shell_drv(
-    cache_directory: Path,
-    shell_file_args: list[str],
-    allow: AllowedFeatures,
-    nix_path: str,
-) -> None:
-    review_drv_link: Path = cache_directory / "review-shell.drv"
-
-    cmd: list[str] = [
-        "nix-instantiate",
-        *_nix_common_flags(allow, nix_path),
-        *shell_file_args,
-        REVIEW_SHELL,
-    ]
-    res = subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if res.returncode != 0:
-        msg = "Failed to instantiate review shell derivation for caching"
-        if res.stderr:
-            msg = f"{msg}: {res.stderr.strip()}"
-        raise NixpkgsReviewError(msg)
-
-    drv_lines = [line.strip() for line in res.stdout.splitlines() if line.strip()]
-    if not drv_lines:
-        msg = "No review shell derivation path produced for caching"
-        raise NixpkgsReviewError(msg)
-
-    drv_path = drv_lines[-1]
-    review_drv_link.unlink(missing_ok=True)
-    review_drv_link.symlink_to(drv_path)

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -27,6 +27,7 @@ class BuildConfig:
     nixpkgs_config: Path
     num_eval_workers: int = 1
     max_memory_size: int = 4096
+    include_tests: bool = False
 
 
 @dataclass
@@ -65,7 +66,11 @@ class Attr:
         return self._path_verified
 
     def is_test(self) -> bool:
-        return self.name.startswith("nixosTests")
+        return (
+            self.name.startswith("nixosTests")
+            or ".tests." in self.name
+            or self.name.endswith(".tests")
+        )
 
     def outputs_with_name(self) -> dict[str, Path]:
         def with_output(output: str) -> str:
@@ -249,6 +254,12 @@ def _nix_eval_filter(packages: NixEvalResult) -> list[Attr]:
         "tests.trivial",
         "tests.writers",
     }
+
+    def is_blacklisted(name: str) -> bool:
+        return name in blacklist or any(
+            name.startswith(f"{entry}.") for entry in blacklist
+        )
+
     attr_by_path: dict[Path, Attr] = {}
     broken = []
     for props in packages:
@@ -266,7 +277,7 @@ def _nix_eval_filter(packages: NixEvalResult) -> list[Attr]:
             name=name,
             exists=extra_value.get("exists", True),
             broken=extra_value.get("broken", True),
-            blacklisted=name in blacklist,
+            blacklisted=is_blacklisted(name),
             outputs=outputs,
             drv_path=drv_path,
         )
@@ -304,7 +315,7 @@ def multi_system_eval(
             str(build_config.max_memory_size),
             *_nix_common_flags(build_config.allow, build_config.nix_path),
             "--expr",
-            f"(import {eval_script} {{ attr-json = {attr_json.name}; }})",
+            f"""(import {eval_script} {{ attr-json = {attr_json.name}; include-tests = {str(build_config.include_tests).lower()}; }})""",
             "--apply",
             "d: { inherit (d) exists broken; }",
         ]

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -286,8 +286,6 @@ def _nix_eval_filter(packages: NixEvalResult) -> list[Attr]:
 def multi_system_eval(
     attr_names_per_system: dict[System, set[str]],
     build_config: BuildConfig,
-    *,
-    instantiate: bool = False,
 ) -> dict[System, list[Attr]]:
     attr_json = NamedTemporaryFile(mode="w+", delete=False)  # noqa: SIM115
     delete = True
@@ -304,7 +302,6 @@ def multi_system_eval(
             str(build_config.num_eval_workers),
             "--max-memory-size",
             str(build_config.max_memory_size),
-            *(() if instantiate else ("--no-instantiate",)),
             *_nix_common_flags(build_config.allow, build_config.nix_path),
             "--expr",
             f"(import {eval_script} {{ attr-json = {attr_json.name}; }})",
@@ -349,21 +346,15 @@ def multi_system_eval(
 
 
 def nix_build(
-    attr_names_per_system: dict[System, set[str]],
+    attrs_per_system: dict[System, list[Attr]],
     args: str,
     cache_directory: Path,
     build_config: BuildConfig,
     build_graph: str,
 ) -> dict[System, list[Attr]]:
-    if not attr_names_per_system:
+    if not attrs_per_system:
         info("Nothing to be built.")
         return {}
-
-    attrs_per_system: dict[System, list[Attr]] = multi_system_eval(
-        attr_names_per_system,
-        build_config,
-        instantiate=True,
-    )
 
     filtered_drv_paths = [
         f"{attr.drv_path}^*"

--- a/nixpkgs_review/nix/review-shell.nix
+++ b/nixpkgs_review/nix/review-shell.nix
@@ -1,36 +1,17 @@
 {
-  local-system,
-  nixpkgs-config-path,
-  # Path to Nix file containing the Nixpkgs config
-  attrs-path,
-  # Path to Nix file containing a list of attributes to build
-  nixpkgs-path,
-  # Path to this review's nixpkgs
-  local-pkgs ? import nixpkgs-path {
-    system = local-system;
-    config = import nixpkgs-config-path;
-  },
-  lib ? local-pkgs.lib,
+  # Path to json file containing the outputs of all built packages
+  outputs-path,
 }:
 
 let
+  inherit (import <nixpkgs> { }) lib buildEnv mkShell;
 
-  nixpkgs-config = import nixpkgs-config-path;
-  extractPackagesForSystem =
-    system: system-attrs:
-    let
-      system-pkg = import nixpkgs-path {
-        inherit system;
-        config = nixpkgs-config;
-      };
-    in
-    map (attrString: lib.attrByPath (lib.splitString "." attrString) null system-pkg) system-attrs;
-  attrs = lib.flatten (lib.mapAttrsToList extractPackagesForSystem (import attrs-path));
-  supportIgnoreSingleFileOutputs = (lib.functionArgs local-pkgs.buildEnv) ? ignoreSingleFileOutputs;
-  env = local-pkgs.buildEnv (
+  outputs = map builtins.storePath (builtins.fromJSON (builtins.readFile outputs-path));
+  supportIgnoreSingleFileOutputs = (lib.functionArgs buildEnv) ? ignoreSingleFileOutputs;
+  env = buildEnv (
     {
       name = "env";
-      paths = attrs;
+      paths = outputs;
       ignoreCollisions = true;
     }
     // lib.optionalAttrs supportIgnoreSingleFileOutputs {
@@ -38,11 +19,11 @@ let
     }
   );
 in
-(import nixpkgs-path { }).mkShell {
+mkShell {
   name = "review-shell";
   preferLocalBuild = true;
   allowSubstitutes = false;
   dontWrapQtApps = true;
   # see test_rev_command_with_pkg_count
-  packages = if builtins.length attrs > 50 then [ env ] else attrs;
+  packages = if builtins.length outputs > 50 then [ env ] else outputs;
 }

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
-    from .nix import Attr
+    from .nix import Attr, BuildConfig
 
 # https://github.com/orgs/community/discussions/27190
 MAX_GITHUB_COMMENT_LENGTH = 65536
@@ -327,6 +327,7 @@ class Report:
         self,
         commit: str | None,
         attrs_per_system: dict[str, list[Attr]],
+        build_config: BuildConfig,
         package_filter: PackageFilter,
         options: ReportOptions | None = None,
     ) -> None:
@@ -337,6 +338,7 @@ class Report:
         self.max_workers = options.max_workers
         self.attrs = attrs_per_system
         self.checkout = options.checkout
+        self.build_config = build_config
         self.package_filter = package_filter
 
         self.extra_nixpkgs_config = (
@@ -410,6 +412,14 @@ class Report:
         for option_name, option_value in options.items():
             if option_value:
                 cmd += f" --{option_name} " + f" --{option_name} ".join(option_value)
+
+        flags = {
+            "tests": self.build_config.include_tests,
+        }
+        for flag_name, flag_enabled in flags.items():
+            if flag_enabled:
+                cmd += f" --{flag_name}"
+
         return cmd
 
     def _generate_header(self, pr: int | None) -> str:

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -350,11 +350,8 @@ class Report:
             reports[system] = SystemReport(attrs)
         self.system_reports: dict[System, SystemReport] = order_reports(reports)
 
-    def built_packages(self) -> dict[System, list[str]]:
-        return {
-            system: [a.name for a in report.built]
-            for system, report in self.system_reports.items()
-        }
+    def built_packages(self) -> dict[System, list[Attr]]:
+        return {system: report.built for system, report in self.system_reports.items()}
 
     def write(self, directory: Path, pr: int | None) -> None:
         # write logs first because snippets from them may be needed for the report

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -638,11 +638,8 @@ class Review:
         if not self.shell_options.no_shell:
             shell_config = ShellConfig(
                 cache_directory=path,
-                local_system=self.build_config.local_system,
                 build_graph=self.shell_options.build_graph,
                 nix_path=self.builddir.nix_path,
-                nixpkgs_config=self.build_config.nixpkgs_config,
-                nixpkgs_overlay=self.builddir.overlay.path,
                 run=self.shell_options.run,
                 sandbox=self.shell_options.sandbox,
             )
@@ -1037,7 +1034,6 @@ def build_config_from_args(
     return BuildConfig(
         allow=allow,
         nix_path=nix_path,
-        local_system=current_system(),
         nixpkgs_config=nixpkgs_config,
         num_eval_workers=args.num_eval_workers,
         max_memory_size=args.max_memory_size,

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -606,6 +606,7 @@ class Review:
         report = Report(
             commit,
             attrs_per_system,
+            self.build_config,
             self.package_filter,
             ReportOptions(
                 extra_nixpkgs_config=self.review_config.extra_nixpkgs_config,
@@ -807,7 +808,7 @@ def _join_packages_for_system(
     changed_attrs: dict[Path, Attr],
     specified_attrs: dict[Path, Attr],
 ) -> dict[Path, Attr]:
-    # ofborg does not include tests and manual evaluation is too expensive
+    # ofborg does not include tests, so don't mark them as nonexistent
     tests = {path for path, attr in specified_attrs.items() if attr.is_test()}
 
     nonexistent = specified_attrs.keys() - changed_attrs.keys() - tests
@@ -1052,6 +1053,8 @@ def build_config_from_args(
     allow: AllowedFeatures,
     nix_path: str,
     nixpkgs_config: Path,
+    *,
+    include_tests: bool,
 ) -> BuildConfig:
     """Create a BuildConfig from parsed CLI arguments."""
     return BuildConfig(
@@ -1060,6 +1063,7 @@ def build_config_from_args(
         nixpkgs_config=nixpkgs_config,
         num_eval_workers=args.num_eval_workers,
         max_memory_size=args.max_memory_size,
+        include_tests=include_tests,
     )
 
 

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -461,17 +461,22 @@ class Review:
     def build(
         self, packages_per_system: dict[System, set[str]], args: str
     ) -> dict[System, list[Attr]]:
-        packages_per_system = filter_packages_per_system(
+        attrs_per_system = filter_packages_per_system(
             packages_per_system,
             self.package_filter,
             self.build_config,
         )
-        packages_per_system = {
-            system: self.package_filter.additional_packages | packages
-            for system, packages in packages_per_system.items()
+        additional_attrs_per_system = eval_packages_per_system(
+            dict.fromkeys(self.systems, self.package_filter.additional_packages),
+            self.build_config,
+        )
+        combined_attrs_per_system = {
+            system: list((attrs | additional_attrs_per_system.get(system, {})).values())
+            for system, attrs in attrs_per_system.items()
         }
+
         return nix_build(
-            packages_per_system,
+            combined_attrs_per_system,
             args,
             self.builddir.path,
             self.build_config,
@@ -801,58 +806,59 @@ def _collect_package_attrs(
 def _join_packages_for_system(
     changed_attrs: dict[Path, Attr],
     specified_attrs: dict[Path, Attr],
-) -> set[str]:
+) -> dict[Path, Attr]:
     # ofborg does not include tests and manual evaluation is too expensive
-    tests = {path: attr for path, attr in specified_attrs.items() if attr.is_test()}
+    tests = {path for path, attr in specified_attrs.items() if attr.is_test()}
 
-    nonexistent = specified_attrs.keys() - changed_attrs.keys() - tests.keys()
+    nonexistent = specified_attrs.keys() - changed_attrs.keys() - tests
 
     if len(nonexistent) != 0:
         die(
             f"The following packages specified with `-p` are not rebuilt by the pull request: "
             f"{' '.join(specified_attrs[path].name for path in nonexistent)}"
         )
-    union_paths = (changed_attrs.keys() & specified_attrs.keys()) | tests.keys()
+    union_paths = (changed_attrs.keys() & specified_attrs.keys()) | tests
 
-    return {specified_attrs[path].name for path in union_paths}
+    return {path: specified_attrs[path] for path in union_paths}
 
 
 def _apply_package_filters(
-    packages: set[str],
+    packages: dict[Path, Attr],
     skip_packages: set[str],
     skip_package_regexes: list[Pattern[str]],
-) -> set[str]:
+) -> dict[Path, Attr]:
     """Apply skip filters to the package set."""
     if skip_packages:
-        packages = packages - skip_packages
+        packages = {
+            path: attr
+            for path, attr in packages.items()
+            if attr.name not in skip_packages
+        }
 
-    for attr in packages.copy():
-        for regex in skip_package_regexes:
-            if regex.match(attr):
-                packages.discard(attr)
-
-    return packages
+    return {
+        path: attr
+        for path, attr in packages.items()
+        if not any(regex.match(attr.name) for regex in skip_package_regexes)
+    }
 
 
 def _match_package_regexes(
-    changed_packages: set[str],
+    changed_attrs: dict[Path, Attr],
     package_regexes: list[Pattern[str]],
-) -> set[str]:
+) -> dict[Path, Attr]:
     """Find packages matching any of the given regex patterns."""
-    packages = set()
-    for attr in changed_packages:
-        for regex in package_regexes:
-            if regex.match(attr):
-                packages.add(attr)
-                break  # No need to check other regexes for this attr
-    return packages
+    return {
+        path: attr
+        for path, attr in changed_attrs.items()
+        if any(regex.match(attr.name) for regex in package_regexes)
+    }
 
 
 def filter_packages_per_system(
     changed_packages_per_system: dict[System, set[str]],
     package_filter: PackageFilter,
     build_config: BuildConfig,
-) -> dict[System, set[str]]:
+) -> dict[System, dict[Path, Attr]]:
     needs_filtering = any(
         [
             package_filter.only_packages,
@@ -864,12 +870,16 @@ def filter_packages_per_system(
 
     # Short-circuit if no filtering is needed
     if not needs_filtering:
-        return changed_packages_per_system
+        return eval_packages_per_system(
+            changed_packages_per_system,
+            build_config,
+        )
 
     # When --package is used, we need to evaluate both changed and specified
     # packages to find their drv paths and intersect them. Batch all systems
     # into a single multi_system_eval call for parallelism.
-    joined_per_system: dict[System, set[str]] = {}
+    joined_per_system: dict[System, dict[Path, Attr]] = {}
+    changed_attrs_per_system: dict[System, dict[Path, Attr]] = {}
     if package_filter.only_packages:
         # Build a combined attr set: all changed + specified packages per system
         changed_eval_input: dict[System, set[str]] = {}
@@ -900,22 +910,23 @@ def filter_packages_per_system(
             joined_per_system[system] = _join_packages_for_system(
                 changed_attrs, specified_attrs
             )
+            changed_attrs_per_system[system] = changed_attrs
 
-    result: dict[System, set[str]] = {}
-    for system, changed_packages in changed_packages_per_system.items():
-        packages: set[str] = set()
+    result: dict[System, dict[Path, Attr]] = {}
+    for system, changed_attrs in changed_attrs_per_system.items():
+        packages: dict[Path, Attr] = {}
 
         if package_filter.only_packages:
-            packages = joined_per_system.get(system, set())
+            packages = joined_per_system.get(system, {})
 
         if package_filter.package_regexes:
             packages |= _match_package_regexes(
-                changed_packages, package_filter.package_regexes
+                changed_attrs, package_filter.package_regexes
             )
 
         # If no packages selected yet, use all changed packages
         if not packages:
-            packages = changed_packages.copy()
+            packages = changed_attrs.copy()
 
         result[system] = _apply_package_filters(
             packages,
@@ -924,6 +935,18 @@ def filter_packages_per_system(
         )
 
     return result
+
+
+def eval_packages_per_system(
+    packages_per_system: dict[System, set[str]],
+    build_config: BuildConfig,
+) -> dict[System, dict[Path, Attr]]:
+    return {
+        system: _collect_package_attrs(results)
+        for system, results in multi_system_eval(
+            packages_per_system, build_config
+        ).items()
+    }
 
 
 @contextmanager

--- a/nixpkgs_review/utils.py
+++ b/nixpkgs_review/utils.py
@@ -69,7 +69,7 @@ def sh(  # noqa: PLR0913
     *,
     cwd: Path | str | None = None,
     env: dict[str, str] | None = None,
-    stdin: str | None = None,
+    stdin: str | int | IO[Any] | None = None,
     stdout: int | None = None,
     stderr: int | None = None,
     quiet: bool = False,
@@ -77,13 +77,22 @@ def sh(  # noqa: PLR0913
     if not quiet:
         info("$ " + shlex.join(command))
     env = os.environ | env if env else None
+
+    input_: str | None = None
+    stdin_: int | IO[Any] | None = None
+    if isinstance(stdin, str):
+        input_ = stdin
+    else:
+        stdin_ = stdin
+
     return subprocess.run(
         command,
         cwd=cwd,
         text=True,
         check=False,
         env=env,
-        input=stdin,
+        input=input_,
+        stdin=stdin_,
         stdout=stdout,
         stderr=stderr,
     )


### PR DESCRIPTION
This PR adds a `--tests` flag to build `passthru.tests` for all packages, as discussed in #77.

The tests to be build can be filtered with `-p`, `-P` and similar, like all other packages.

```
$ nixpkgs-review pr --tests 303033
...
Link to currently reviewing PR:
https://github.com/NixOS/nixpkgs/pull/303033

1 tests built:
netbird.passthru.tests.netbird

2 packages built:
netbird netbird-ui
...
```

```
$ nixpkgs-review pr --tests --package-regex 'netbird.+' 303033
...
1 tests built:
netbird.passthru.tests.netbird

1 package built:
netbird-ui
...
```

Since they are classified as tests, they can also be enabled individually with `-p`, without specifying `--tests`:
```
$ nixpkgs-review pr -p netbird.passthru.tests.netbird 303033
...
1 tests built:
netbird.passthru.tests.netbird
...
```

Fixes: #77