### PR TITLE
print copiable commands

### DIFF
--- a/nixpkgs_review/utils.py
+++ b/nixpkgs_review/utils.py
@@ -1,5 +1,6 @@
 import functools
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -29,7 +30,7 @@ link = color_text(34)
 def sh(
     command: list[str], cwd: Path | str | None = None
 ) -> "subprocess.CompletedProcess[str]":
-    info("$ " + " ".join(command))
+    info("$ " + shlex.join(command))
     return subprocess.run(command, cwd=cwd, text=True)
 
 


### PR DESCRIPTION
[shlex.join](https://docs.python.org/3/library/shlex.html#shlex.join) handle adding ' when argument contains space. Before it was printed like this: `--extra-experimental-features nix-command no-url-literals`