### PR TITLE
Make `--no-shell` not exit early

### DIFF
--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -78,8 +78,13 @@ def pr_command(args: argparse.Namespace) -> str:
                 warn(f"https://github.com/NixOS/nixpkgs/pull/{pr} failed to build: {e}")
         assert review is not None
 
-        for pr, path, attrs in contexts:
+        all_succeeded = all(
             review.start_review(attrs, path, pr, args.post_result, args.print_result)
+            for pr, path, attrs in contexts
+        )
+
+        if args.no_shell:
+            sys.exit(0 if all_succeeded else 1)
 
         if len(contexts) != len(prs):
             sys.exit(1)

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -267,7 +267,7 @@ class Review:
         pr: int | None = None,
         post_result: bool | None = False,
         print_result: bool = False,
-    ) -> None:
+    ) -> bool:
         os.environ.pop("NIXPKGS_CONFIG", None)
         os.environ["NIXPKGS_REVIEW_ROOT"] = str(path)
         if pr:
@@ -282,9 +282,7 @@ class Review:
         if print_result:
             print(report.markdown(pr))
 
-        if self.no_shell:
-            sys.exit(0 if report.succeeded() else 1)
-        else:
+        if not self.no_shell:
             nix_shell(
                 report.built_packages(),
                 path,
@@ -296,6 +294,8 @@ class Review:
                 self.run,
                 self.sandbox,
             )
+
+        return report.succeeded()
 
     def review_commit(
         self,


### PR DESCRIPTION
This makes `--no-shell --post-result` with multiple PRs post more than just the first report.