### PR TITLE
fix: distinguish build failures from store failures

### DIFF
--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -33,7 +33,17 @@ class Attr:
             return self._path_verified
 
         res = subprocess.run(
-            ["nix-store", "--verify-path", self.path], stderr=subprocess.DEVNULL
+            [
+                "nix",
+                "--extra-experimental-features",
+                "nix-command",
+                "store",
+                "verify",
+                "--no-contents",
+                "--no-trust",
+                self.path,
+            ],
+            stderr=subprocess.DEVNULL,
         )
         self._path_verified = res.returncode == 0
         return self._path_verified


### PR DESCRIPTION
"nix-store --verify-path" exits with status 1 in various situations, including when the path does not exist (due to having failed to build) or when the checksum doesn't match the Nix database.

Since nixpkgs-review tries to report build failures specifically, use "nix store verify" instead with its "--no-contents" flag. This avoids classifying checksum mismatches as build failures, which can be misleading to nixpkgs-review users.

Though still an abnormal situation that might be useful to report, we now ignore store path errors; these are generally an abnormal situation, and detecting them is out-of-scope for nixpkgs-review.  Should it become clearer that it would be useful to report them, it could be done by removing --no-contents and checking "nix store verify"'s exit status, which indicates the nature of the problem.

Fixes https://github.com/Mic92/nixpkgs-review/issues/415