### PR TITLE
Feat: add support for multi-systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,19 +175,38 @@ done
 inside the nix-shell instead of an interactive session:
 
 ```console
-$ nixpkgs-review pr --run 'jq < report.json' 113814
+$ nixpkgs-review pr --run --systems all 'jq < report.json' 340297
 # ...
 {
-  "blacklisted": [],
-  "broken": [],
-  "built": [
-    "cargo-deny"
-  ],
-  "failed": [],
-  "non-existent": [],
-  "pr": 113814,
-  "system": "x86_64-linux",
-  "tests": []
+  "checkout": "merge",
+  "extra-nixpkgs-config": null,
+  "pr": 340297,
+  "result": {
+    "aarch64-linux": {
+      "blacklisted": [],
+      "broken": [],
+      "built": [
+        "forecast"
+      ],
+      "failed": [],
+      "non-existent": [],
+      "tests": []
+    },
+    "x86_64-linux": {
+      "blacklisted": [],
+      "broken": [],
+      "built": [
+        "forecast"
+      ],
+      "failed": [],
+      "non-existent": [],
+      "tests": []
+    }
+  },
+  "systems": [
+    "x86_64-linux",
+    "aarch64-linux"
+  ]
 }
 ```
 
@@ -326,9 +345,17 @@ subcommand.
 
 ## Review changes for other operating systems/architectures
 
-The `--system` flag allows setting a system different from the current one. Note
-that the result nix-shell may not be able to execute all hooks correctly since
-the architecture/operating system mismatches.
+The `--systems` flag allows setting a system different from the current one.
+Note that the result nix-shell may not be able to execute all hooks correctly
+since the architecture/operating system mismatches.
+
+By default, `nixpkgs-review` targets only the current system
+(`--systems current`). You can also explicitly provide one or several systems to
+target (`--systems "x86_64-linux aarch64-darwin"`). The `--systems all` value
+will build for the four major platforms supported by hydra (`--x86_64-linux`,
+`aarch64-linux`, `x86_64-darwin` and `aarch64-darwin`). Ensure that your system
+is capable of building for the specified architectures, either locally or
+through the remote builder protocol.
 
 ```console
 $ nixpkgs-review pr --system aarch64-linux 98734

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -9,7 +9,7 @@ from re import Pattern
 from shutil import which
 from typing import Any, cast
 
-from ..utils import current_system, nix_nom_tool
+from ..utils import nix_nom_tool
 from .approve import approve_command
 from .comments import show_comments
 from .merge import merge_command
@@ -214,10 +214,16 @@ def common_flags() -> list[CommonFlag]:
             help="Regular expression that package attributes have not to match (can be passed multiple times)",
         ),
         CommonFlag(
+            "--systems",
+            type=str,
+            default="current",
+            help="Nix 'systems' to evaluate and build packages for",
+        ),
+        CommonFlag(
             "--system",
             type=str,
-            default=current_system(),
-            help="Nix 'system' to evaluate and build packages for",
+            default="",
+            help="[DEPRECATED] use `--systems` instead",
         ),
         CommonFlag(
             "--token",

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -249,6 +249,12 @@ def common_flags() -> list[CommonFlag]:
             default="{ }",
             help="Extra nixpkgs config to pass to `import <nixpkgs>`",
         ),
+        CommonFlag(
+            "--num-procs-eval",
+            type=int,
+            default=1,
+            help="Number of parallel `nix-env` processes to run simultaneously (warning, can imply heavy RAM usage)",
+        ),
     ]
 
 

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -86,6 +86,7 @@ def pr_command(args: argparse.Namespace) -> str:
                     build_graph=args.build_graph,
                     nixpkgs_config=nixpkgs_config,
                     extra_nixpkgs_config=args.extra_nixpkgs_config,
+                    n_procs_eval=args.num_procs_eval,
                 )
                 contexts.append((pr, builddir.path, review.build_pr(pr)))
             except NixpkgsReviewError as e:

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -11,7 +11,7 @@ from typing import Any, Final
 
 from .allow import AllowedFeatures
 from .errors import NixpkgsReviewError
-from .utils import ROOT, escape_attr, info, sh, warn
+from .utils import ROOT, System, info, sh, warn
 
 
 @dataclass
@@ -56,9 +56,9 @@ REVIEW_SHELL: Final[str] = str(ROOT.joinpath("nix/review-shell.nix"))
 
 
 def nix_shell(
-    attrs: list[str],
+    attrs_per_system: dict[System, list[str]],
     cache_directory: Path,
-    system: str,
+    local_system: str,
     build_graph: str,
     nix_path: str,
     nixpkgs_config: Path,
@@ -71,7 +71,10 @@ def nix_shell(
         raise RuntimeError(f"{build_graph} not found in PATH")
 
     shell_file_args = build_shell_file_args(
-        cache_directory, attrs, system, nixpkgs_config
+        cache_dir=cache_directory,
+        attrs_per_system=attrs_per_system,
+        local_system=local_system,
+        nixpkgs_config=nixpkgs_config,
     )
     if sandbox:
         args = _nix_shell_sandbox(
@@ -267,27 +270,33 @@ def nix_eval(
 
 
 def nix_build(
-    attr_names: set[str],
+    attr_names_per_system: dict[System, set[str]],
     args: str,
     cache_directory: Path,
-    system: str,
+    systems: set[System],
+    local_system: System,
     allow: AllowedFeatures,
     build_graph: str,
     nix_path: str,
     nixpkgs_config: Path,
-) -> list[Attr]:
-    if not attr_names:
+) -> dict[System, list[Attr]]:
+    if not attr_names_per_system:
         info("Nothing to be built.")
-        return []
+        return {}
 
-    attrs = nix_eval(attr_names, system, allow, nix_path)
-    filtered = []
-    for attr in attrs:
-        if not (attr.broken or attr.blacklisted):
-            filtered.append(attr.name)
+    # TODO parallelize evaluation
+    attrs_per_system: dict[System, list[Attr]] = {}
+    filtered_per_system: dict[System, list[str]] = {}
+    for system, attr_names in attr_names_per_system.items():
+        attrs_per_system[system] = nix_eval(attr_names, system, allow, nix_path)
 
-    if len(filtered) == 0:
-        return attrs
+        filtered_per_system[system] = []
+        for attr in attrs_per_system[system]:
+            if not (attr.broken or attr.blacklisted):
+                filtered_per_system[system].append(attr.name)
+
+    if all(len(filtered) == 0 for filtered in filtered_per_system.values()):
+        return attrs_per_system
 
     command = [
         build_graph,
@@ -314,26 +323,37 @@ def nix_build(
         ]
 
     command += build_shell_file_args(
-        cache_directory, filtered, system, nixpkgs_config
+        cache_dir=cache_directory,
+        attrs_per_system=filtered_per_system,
+        local_system=local_system,
+        nixpkgs_config=nixpkgs_config,
     ) + shlex.split(args)
 
     sh(command)
-    return attrs
+    return attrs_per_system
 
 
 def build_shell_file_args(
-    cache_dir: Path, attrs: list[str], system: str, nixpkgs_config: Path
+    cache_dir: Path,
+    attrs_per_system: dict[System, list[str]],
+    local_system: str,
+    nixpkgs_config: Path,
 ) -> list[str]:
     attrs_file = cache_dir.joinpath("attrs.nix")
     with open(attrs_file, "w+", encoding="utf-8") as f:
-        f.write("pkgs: with pkgs; [\n")
-        f.write("\n".join(f"  {escape_attr(a)}" for a in attrs))
-        f.write("\n]")
+        f.write("{\n")
+        for system, attrs in attrs_per_system.items():
+            f.write(f"  {system} = [\n")
+            for attr in attrs:
+                f.write(f'    "{attr}"\n')
+            f.write("  ];\n")
+        f.write("}")
+        print(f.read())
 
     return [
         "--argstr",
-        "system",
-        system,
+        "local-system",
+        local_system,
         "--argstr",
         "nixpkgs-path",
         str(cache_dir.joinpath("nixpkgs/")),

--- a/nixpkgs_review/nix/review-shell.nix
+++ b/nixpkgs_review/nix/review-shell.nix
@@ -1,14 +1,32 @@
-{ system
-, nixpkgs-config-path # Path to Nix file containing the Nixpkgs config
-, attrs-path # Path to Nix file containing a list of attributes to build
-, nixpkgs-path # Path to this review's nixpkgs
-, pkgs ? import nixpkgs-path { inherit system; config = import nixpkgs-config-path; }
-, lib ? pkgs.lib
+{ local-system
+, nixpkgs-config-path
+, # Path to Nix file containing the Nixpkgs config
+  attrs-path
+, # Path to Nix file containing a list of attributes to build
+  nixpkgs-path
+, # Path to this review's nixpkgs
+  local-pkgs ? import nixpkgs-path {
+    system = local-system;
+    config = import nixpkgs-config-path;
+  }
+, lib ? local-pkgs.lib
+,
 }:
 
 let
-  attrs = import attrs-path pkgs;
-  env = pkgs.buildEnv {
+
+  nixpkgs-config = import nixpkgs-config-path;
+  extractPackagesForSystem =
+    system: system-attrs:
+    let
+      system-pkg = import nixpkgs-path {
+        inherit system;
+        config = nixpkgs-config;
+      };
+    in
+    map (attrString: lib.attrByPath (lib.splitString "." attrString) null system-pkg) system-attrs;
+  attrs = lib.flatten (lib.mapAttrsToList extractPackagesForSystem (import attrs-path));
+  env = local-pkgs.buildEnv {
     name = "env";
     paths = attrs;
     ignoreCollisions = true;

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -107,6 +107,7 @@ class Review:
         skip_packages_regex: list[Pattern[str]] = [],
         checkout: CheckoutOption = CheckoutOption.MERGE,
         sandbox: bool = False,
+        n_procs_eval: int = 1,
     ) -> None:
         self.builddir = builddir
         self.build_args = build_args
@@ -139,6 +140,7 @@ class Review:
         self.build_graph = build_graph
         self.nixpkgs_config = nixpkgs_config
         self.extra_nixpkgs_config = extra_nixpkgs_config
+        self.n_procs_eval = n_procs_eval
 
     def worktree_dir(self) -> str:
         return str(self.builddir.worktree_dir)
@@ -260,6 +262,7 @@ class Review:
             self.build_graph,
             self.builddir.nix_path,
             self.nixpkgs_config,
+            self.n_procs_eval,
         )
 
     def build_pr(self, pr_number: int) -> dict[System, list[Attr]]:
@@ -624,6 +627,7 @@ def review_local_revision(
             build_graph=args.build_graph,
             nixpkgs_config=nixpkgs_config,
             extra_nixpkgs_config=args.extra_nixpkgs_config,
+            n_procs_eval=args.num_procs_eval,
         )
         review.review_commit(builddir.path, args.branch, commit, staged, print_result)
         return builddir.path

--- a/nixpkgs_review/utils.py
+++ b/nixpkgs_review/utils.py
@@ -6,10 +6,12 @@ import subprocess
 import sys
 from collections.abc import Callable
 from pathlib import Path
-from typing import IO, Any
+from typing import IO, Any, TypeAlias
 
 HAS_TTY = sys.stdout.isatty()
 ROOT = Path(os.path.dirname(os.path.realpath(__file__)))
+
+System: TypeAlias = str
 
 
 def color_text(code: int, file: IO[Any] | None = None) -> Callable[[str], None]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,8 @@ from typing import Any, cast
 
 import pytest
 
+from nixpkgs_review.utils import current_system
+
 TEST_ROOT = Path(__file__).parent.resolve()
 sys.path.append(str(TEST_ROOT.parent))
 
@@ -115,6 +117,11 @@ class Helpers:
     def load_report(review_dir: str) -> dict[str, Any]:
         with open(os.path.join(review_dir, "report.json")) as f:
             return cast(dict[str, Any], json.load(f))
+
+    @staticmethod
+    def assert_built(pkg_name: str, path: str) -> None:
+        report = Helpers.load_report(path)
+        assert report["result"][current_system()]["built"] == [pkg_name]
 
     @staticmethod
     @contextmanager

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -40,8 +40,7 @@ def test_pr_local_eval(helpers: Helpers, capfd: pytest.CaptureFixture) -> None:
                 "1",
             ],
         )
-        report = helpers.load_report(path)
-        assert report["built"] == ["pkg1"]
+        helpers.assert_built(pkg_name="pkg1", path=path)
         captured = capfd.readouterr()
         assert "$ nom build" in captured.out
 
@@ -69,8 +68,7 @@ def test_pr_local_eval_missing_nom(
                 "1",
             ],
         )
-        report = helpers.load_report(path)
-        assert report["built"] == ["pkg1"]
+        helpers.assert_built(pkg_name="pkg1", path=path)
         mock_tool.assert_called_once()
         captured = capfd.readouterr()
         assert "$ nix build" in captured.out
@@ -100,8 +98,7 @@ def test_pr_local_eval_without_nom(
                 "nix",
             ],
         )
-        report = helpers.load_report(path)
-        assert report["built"] == ["pkg1"]
+        helpers.assert_built(pkg_name="pkg1", path=path)
         captured = capfd.readouterr()
         assert "$ nix build" in captured.out
 
@@ -128,8 +125,7 @@ def test_pr_local_eval_with_sandbox(helpers: Helpers) -> None:
                 "1",
             ],
         )
-        report = helpers.load_report(path)
-        assert report["built"] == ["pkg1"]
+        helpers.assert_built(pkg_name="pkg1", path=path)
 
 
 @patch("urllib.request.urlopen")
@@ -161,5 +157,4 @@ def test_pr_ofborg_eval(mock_urlopen: MagicMock, helpers: Helpers) -> None:
                 "37200",
             ],
         )
-        report = helpers.load_report(path)
-        assert report["built"] == ["pkg1"]
+        helpers.assert_built(pkg_name="pkg1", path=path)

--- a/tests/test_rev.py
+++ b/tests/test_rev.py
@@ -21,8 +21,7 @@ def test_rev_command(helpers: Helpers) -> None:
             "nixpkgs-review",
             ["rev", "HEAD", "--remote", str(nixpkgs.remote), "--run", "exit 0"],
         )
-        report = helpers.load_report(path)
-        assert report["built"] == ["pkg1"]
+        helpers.assert_built(pkg_name="pkg1", path=path)
 
 
 def test_rev_command_without_nom(helpers: Helpers) -> None:
@@ -44,5 +43,4 @@ def test_rev_command_without_nom(helpers: Helpers) -> None:
                 "nix",
             ],
         )
-        report = helpers.load_report(path)
-        assert report["built"] == ["pkg1"]
+        helpers.assert_built(pkg_name="pkg1", path=path)

--- a/tests/test_wip.py
+++ b/tests/test_wip.py
@@ -18,8 +18,7 @@ def test_wip_command(helpers: Helpers, capfd: pytest.CaptureFixture) -> None:
             "nixpkgs-review",
             ["wip", "--remote", str(nixpkgs.remote), "--run", "exit 0"],
         )
-        report = helpers.load_report(path)
-        assert report["built"] == ["pkg1"]
+        helpers.assert_built(pkg_name="pkg1", path=path)
         captured = capfd.readouterr()
         assert "$ nom build" in captured.out
 
@@ -42,7 +41,6 @@ def test_wip_command_without_nom(
                 "nix",
             ],
         )
-        report = helpers.load_report(path)
-        assert report["built"] == ["pkg1"]
+        helpers.assert_built(pkg_name="pkg1", path=path)
         captured = capfd.readouterr()
         assert "$ nix build" in captured.out


### PR DESCRIPTION
This PR addresses #400 by allowing to evaluate a PR/revision for multiple systems at once.
You can now provide the `--systems` option with a list of systems to evaluate:
- `--systems current` (default): legacy behavior
- `--systems "x86_64-linux aarch64-darwin"`: evaluate for both intel linux and ARM darwin
- `--systems all`: evaluate on all four main platforms

### Progress

- [x] Overall refactoring, addition of the necessary abstractions
- [x] Adapted all "output" features (`report.json`, `report.md`, stdout...)
- [x] Support for `--eval ofborg`
- [x] Support for `--eval local` (sequential)
- [ ] ~~Support for `--eval local` (optionally parallel)~~ -> Let's do this in a following PR. This one is already big enough.
- [x] Flesh out documentation
- [x] Final code polishing

> [!Note]
>
> This is still a WIP. ~~The tool works fine when using ofborg eval but I have not yet adapted to local evaluation.~~
> The code is quite dirty for now and will require more polish ~~once everything will be working~~.
> Also, I am fully open to suggestions regarding the solution and coding style.


I am eager to receive some feedback !

### Technical details

- Basically, adding this feature requires a pretty heavy refactoring.
Every place where there was a list of attributes/packages/reports, we now need a `dict` mapping each `system` to this list.
- I also needed to change the code for the nix shell to build as it now combines the packages to build for all platforms in the final attribute list.
- The current `--system` option has been softly deprecated (warning + forwarding the value to `--systems`) to avoid breaking the workflow of existing users.
- **Note:** I also had to change the layout of the `report.json`.

cc @Mic92 @natsukium
