### PR TITLE
Sort systems in stdout

### DIFF
--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Literal
 
 from .nix import Attr
-from .utils import System, info, link, skipped, warn
+from .utils import System, info, link, skipped, system_order_key, warn
 
 
 def print_number(
@@ -141,7 +141,7 @@ def order_reports(reports: dict[System, SystemReport]) -> dict[System, SystemRep
     return dict(
         sorted(
             reports.items(),
-            key=lambda item: "".join(reversed(item[0].split("-"))),
+            key=lambda item: system_order_key(system=item[0]),
             reverse=True,
         )
     )

--- a/nixpkgs_review/utils.py
+++ b/nixpkgs_review/utils.py
@@ -76,3 +76,20 @@ def nix_nom_tool() -> str:
         return "nom"
 
     return "nix"
+
+
+def system_order_key(system: System) -> str:
+    """
+    For a consistent UI, we keep the platforms sorted as such:
+    - x86_64-linux
+    - aarch64-linux
+    - x86_64-darwin
+    - aarch64-darwin
+
+    This helper turns a system name to an alias which can then be sorted in the anti-alphabetical order.
+    (i.e. should be used in `sort` with `reverse=True`)
+
+    Example:
+    `aarch64-linux` -> `linuxaarch64`
+    """
+    return "".join(reversed(system.split("-")))


### PR DESCRIPTION
The script displays 'Impacted packages' for each system.
This ensures that the systems are enumerated in the canonical order.
