### PR TITLE
Add --git-config flag

### DIFF
--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -164,6 +164,12 @@ def common_flags() -> list[CommonFlag]:
             "--build-args", default="", help="arguments passed to nix when building"
         ),
         CommonFlag(
+            "--git-config",
+            action="append",
+            default=[],
+            help="additional Git configuration to use (accept multiple specification)",
+        ),
+        CommonFlag(
             "--no-shell",
             action="store_true",
             help="Only evaluate and build without executing nix-shell",

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -70,6 +70,7 @@ def pr_command(args: argparse.Namespace) -> str:
                 review = Review(
                     builddir=builddir,
                     build_args=args.build_args,
+                    git_configs=args.git_config,
                     no_shell=args.no_shell,
                     run=args.run,
                     remote=args.remote,

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 from dataclasses import dataclass, field
 from enum import Enum
+from itertools import chain
 from pathlib import Path
 from re import Pattern
 from typing import IO
@@ -92,6 +93,7 @@ class Review:
         self,
         builddir: Builddir,
         build_args: str,
+        git_configs: list[str],
         no_shell: bool,
         run: str,
         remote: str,
@@ -112,6 +114,7 @@ class Review:
     ) -> None:
         self.builddir = builddir
         self.build_args = build_args
+        self.git_configs = git_configs
         self.no_shell = no_shell
         self.run = run
         self.remote = remote
@@ -146,9 +149,15 @@ class Review:
     def worktree_dir(self) -> str:
         return str(self.builddir.worktree_dir)
 
+    def form_git_command(self, main_args: [str]) -> [str]:
+        result = ["git"]
+        result.extend(chain(*(["-c", c] for c in self.git_configs)))
+        result.extend(main_args)
+        return result
+
     def git_merge(self, commit: str) -> None:
         res = sh(
-            ["git", "merge", "--no-commit", "--no-ff", commit], cwd=self.worktree_dir()
+            self.form_git_command(["merge", "--no-commit", "--no-ff", commit]), cwd=self.worktree_dir()
         )
         if res.returncode != 0:
             raise NixpkgsReviewError(
@@ -156,7 +165,7 @@ class Review:
             )
 
     def apply_unstaged(self, staged: bool = False) -> None:
-        args = ["git", "--no-pager", "diff", "--no-ext-diff"]
+        args = self.form_git_command(["--no-pager", "diff", "--no-ext-diff"])
         args.extend(["--staged"] if staged else [])
         with subprocess.Popen(args, stdout=subprocess.PIPE) as diff_proc:
             assert diff_proc.stdout
@@ -167,7 +176,7 @@ class Review:
             sys.exit(0)
 
         info("Applying `nixpkgs` diff...")
-        result = subprocess.run(["git", "apply"], cwd=self.worktree_dir(), input=diff)
+        result = subprocess.run(self.form_git_command(["apply"]), cwd=self.worktree_dir(), input=diff)
 
         if result.returncode != 0:
             warn(f"Failed to apply diff in {self.worktree_dir()}")
@@ -222,7 +231,7 @@ class Review:
         return self.build(changed_attrs, self.build_args)
 
     def git_worktree(self, commit: str) -> None:
-        res = sh(["git", "worktree", "add", self.worktree_dir(), commit])
+        res = sh(self.form_git_command(["worktree", "add", self.worktree_dir(), commit]))
         if res.returncode != 0:
             raise NixpkgsReviewError(
                 f"Failed to add worktree for {commit} in {self.worktree_dir()}. git worktree failed with exit code {res.returncode}"
@@ -637,6 +646,7 @@ def review_local_revision(
         review = Review(
             builddir=builddir,
             build_args=args.build_args,
+            git_configs=args.git_config,
             no_shell=args.no_shell,
             run=args.run,
             remote=args.remote,


### PR DESCRIPTION
This PR adds a `--git-config` flag to pass additional Git configurations to the Git executable via the `-c name value` arguments. This flag can be specified multiple times, preserving spaces inside the configuration values in each specification.

This flag allows running `nixpkgs-review` with trusted users (usually `root`) but with the original user's Git configurations (such as `user.name` and `user.email`), which helps gain builder access for multi-system reviews.