### PR TITLE
fix example CLI flags for the sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ nixpkgs so we can try to fix this issue.
 
 ```console
 $ nix-shell -p bubblewrap # or install it using NixOS/Home-Manager/etc.
-$ nixpkgs-review --sandbox pr 98734
+$ nixpkgs-review pr --sandbox 98734
 ```
 
 ## Roadmap


### PR DESCRIPTION
```console
> nixpkgs-review --sandbox pr 361460
usage: /nix/store/lzz1i98h78miinzx3yg6ly7kl4ypxd42-nixpkgs-review-3.0.0/bin/nixpkgs-review
       [-h] [--version]
       {post-result,approve,comments,merge,pr,rev,wip} ...
/nix/store/lzz1i98h78miinzx3yg6ly7kl4ypxd42-nixpkgs-review-3.0.0/bin/nixpkgs-review: error: unrecognized arguments: --sandbox

> nixpkgs-review pr --sandbox 361460
-> Attempting to fetch eval results from GitHub actions
-> Successfully fetched rebuilds: no local evaluation needed
...
Using sandbox mode. Some things may break!
```