### PR TITLE
nixpkgs-review: ensure cache directory is an absolute path

### DIFF
--- a/nixpkgs_review/builddir.py
+++ b/nixpkgs_review/builddir.py
@@ -39,6 +39,9 @@ def create_cache_directory(name: str) -> Union[Path, "TemporaryDirectory[str]"]:
 
         xdg_cache = Path(home).joinpath(".cache")
 
+    # There is no guarantee that environment variables are set to absolute paths.
+    xdg_cache = xdg_cache.absolute()
+
     counter = 0
     while True:
         try:


### PR DESCRIPTION
Closes #467. Forces an absolute path by calling `Path.absolute`.

The early return of `return TemporaryDirectory()` a few lines above the diff does not affect this,
as `TemporaryDirectory` will always return an absolute pathname because it uses [the same rules as `mkdtemp`](https://docs.python.org/3.11/library/tempfile.html#tempfile.TemporaryDirectory).

Specifically, for Python 3.11 and lower, `mkdtemp` [will always return an absolute path](https://docs.python.org/3.11/library/tempfile.html#tempfile.mkdtemp) when `dir` is None, and since Python 3.12, will always return an absolute pathname.