### PR TITLE
Switch to `nix-eval-jobs` for local evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,10 @@ attribute set:
 $ nixpkgs-review pr -p nixosTests.ferm 47077
 ```
 
+Many packages also specify their associated `nixosTests` in the `passthru.tests`
+attribute set. Adding the `--tests` argument will run those tests for all
+packages that will be rebuild.
+
 ## Ignoring ofborg evaluations
 
 By default, nixpkgs-review will use ofborg's evaluation result if available to

--- a/default.nix
+++ b/default.nix
@@ -10,6 +10,18 @@ let
   withNom' =
     withNom
     && (builtins.tryEval (builtins.elem buildPlatform.system pkgs.ghc.meta.platforms)).value or false;
+
+  # at least v2.26.0 (currently unreleased) is required for the '--apply' flag
+  nix-eval-jobs =
+    if lib.versionOlder pkgs.nix-eval-jobs.version "2.26.0" then
+      callPackage (fetchFromGitHub {
+        owner = "nix-community";
+        repo = "nix-eval-jobs";
+        rev = "6d4fd5a93d7bc953ffa4dcd6d53ad7056a71eff7";
+        hash = "sha256-1dZLPw+nlFQzzswfyTxW+8VF1AJ4ZvoYvLTjlHiz1SA=";
+      }) { nix = nixVersions.nix_2_25; }
+    else
+      pkgs.nix-eval-jobs;
 in
 python3Packages.buildPythonApplication {
   name = "nixpkgs-review";
@@ -46,6 +58,7 @@ python3Packages.buildPythonApplication {
         [
           pkgs.nixVersions.stable or nix_2_4
           git
+          nix-eval-jobs
         ]
         ++ lib.optional withSandboxSupport bubblewrap
         ++ lib.optional withNom' nix-output-monitor;

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
 

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -180,6 +180,11 @@ def common_flags() -> list[CommonFlag]:
             help="Regular expression that package attributes have to match (can be passed multiple times)",
         ),
         CommonFlag(
+            "--tests",
+            action="store_true",
+            help="For all packages to be built, also build their `passthru.tests`",
+        ),
+        CommonFlag(
             "-r",
             "--remote",
             default="https://github.com/NixOS/nixpkgs",

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -250,7 +250,13 @@ def common_flags() -> list[CommonFlag]:
             "--num-parallel-evals",
             type=int,
             default=1,
-            help="Number of parallel `nix-env`/`nix eval` processes to run simultaneously (warning, can imply heavy RAM usage)",
+            help="Number of parallel `nix-eval-jobs` workers to run simultaneously (warning, can imply heavy RAM usage)",
+        ),
+        CommonFlag(
+            "--max-memory-size",
+            type=int,
+            default=4096,
+            help="Maximum `nix-eval-jobs` per worker memory size in megabyte (warning, workers can shortly exceed the limit)",
         ),
     ]
 

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -110,6 +110,7 @@ def pr_command(args: argparse.Namespace) -> str:
                     build_graph=args.build_graph,
                     nixpkgs_config=nixpkgs_config,
                     extra_nixpkgs_config=args.extra_nixpkgs_config,
+                    build_passthru_tests=args.tests,
                     num_parallel_evals=args.num_parallel_evals,
                     max_memory_size=args.max_memory_size,
                     show_header=not args.no_headers,

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -111,6 +111,7 @@ def pr_command(args: argparse.Namespace) -> str:
                     nixpkgs_config=nixpkgs_config,
                     extra_nixpkgs_config=args.extra_nixpkgs_config,
                     num_parallel_evals=args.num_parallel_evals,
+                    max_memory_size=args.max_memory_size,
                     show_header=not args.no_headers,
                 )
                 contexts.append((pr, builddir.path, review.build_pr(pr)))

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -50,7 +50,7 @@ class Attr:
         return self._path_verified
 
     def is_test(self) -> bool:
-        return self.name.startswith("nixosTests")
+        return self.name.startswith("nixosTests") or ".passthru.tests." in self.name
 
     def outputs_with_name(self) -> dict[str, Path]:
         def with_output(output: str) -> str:
@@ -207,6 +207,12 @@ def _nix_eval_filter(json: list[Any]) -> list[Attr]:
         "tests.trivial",
         "tests.writers",
     }
+
+    def is_blacklisted(name: str) -> bool:
+        return name in blacklist or any(
+            name.startswith(f"{entry}.") for entry in blacklist
+        )
+
     attr_by_path: dict[Path, Attr] = {}
     broken = []
     for props in json:
@@ -222,7 +228,7 @@ def _nix_eval_filter(json: list[Any]) -> list[Attr]:
             name=name,
             exists=props["exists"],
             broken=props["broken"],
-            blacklisted=name in blacklist,
+            blacklisted=is_blacklisted(name),
             outputs=outputs,
             drv_path=drv_path,
         )
@@ -247,6 +253,7 @@ def nix_eval(
     nix_path: str,
     num_parallel_evals: int,
     max_memory_size: int,
+    include_passthru_tests: bool = False,
 ) -> list[Attr]:
     return multi_system_eval(
         {system: attrs},
@@ -254,6 +261,7 @@ def nix_eval(
         nix_path=nix_path,
         num_parallel_evals=num_parallel_evals,
         max_memory_size=max_memory_size,
+        include_passthru_tests=include_passthru_tests,
     ).get(system, [])
 
 
@@ -263,6 +271,7 @@ def multi_system_eval(
     nix_path: str,
     num_parallel_evals: int,
     max_memory_size: int,
+    include_passthru_tests: bool = False,
 ) -> dict[System, list[Attr]]:
     attr_json = NamedTemporaryFile(mode="w+", delete=False)  # noqa: SIM115
     delete = True
@@ -282,7 +291,10 @@ def multi_system_eval(
             "--extra-experimental-features",
             "" if allow.url_literals else "no-url-literals",
             "--expr",
-            f"(import {eval_script} {{ attr-json = {attr_json.name}; }})",
+            f"""(import {eval_script} {{
+              attr-json = {attr_json.name};
+              include-passthru-tests = {str(include_passthru_tests).lower()};
+            }})""",
             "--nix-path",
             nix_path,
             "--allow-import-from-derivation"

--- a/nixpkgs_review/nix/evalAttrs.nix
+++ b/nixpkgs_review/nix/evalAttrs.nix
@@ -1,52 +1,56 @@
 { attr-json }:
 
 with builtins;
-let
-  pkgs = import <nixpkgs> {
-    config = import (getEnv "NIXPKGS_CONFIG") // {
-      allowBroken = false;
+mapAttrs (
+  system: attrs:
+  let
+    pkgs = import <nixpkgs> {
+      inherit system;
+      config = import (getEnv "NIXPKGS_CONFIG") // {
+        allowBroken = false;
+      };
     };
-  };
 
-  inherit (pkgs) lib;
+    inherit (pkgs) lib;
 
-  attrs = fromJSON (readFile attr-json);
-  getProperties =
-    name:
-    let
-      attrPath = lib.splitString "." name;
-      pkg = lib.attrByPath attrPath null pkgs;
-      exists = lib.hasAttrByPath attrPath pkgs;
-    in
-    if pkg == null then
-      [
-        (lib.nameValuePair name {
-          inherit exists;
-          broken = true;
-          path = null;
-          drvPath = null;
-        })
-      ]
-    else if !lib.isDerivation pkg then
-      if builtins.typeOf pkg != "set" then
-        # if it is not a package, ignore it (it is probably something like overrideAttrs)
-        [ ]
+    # nix-eval-jobs only shows derivations, so create an empty one to return
+    fake = derivation {
+      name = "fake";
+      system = "fake";
+      builder = "fake";
+    };
+
+    getProperties =
+      name:
+      let
+        attrPath = lib.splitString "." name;
+        maybePkg = tryEval (lib.attrByPath attrPath null pkgs);
+        pkg = maybePkg.value;
+        exists = lib.hasAttrByPath attrPath pkgs;
+      in
+      # some packages are set to null or throw if they aren't compatible with a platform or package set
+      if !maybePkg.success || pkg == null then
+        [
+          (lib.nameValuePair name (
+            fake
+            // {
+              inherit exists;
+              broken = true;
+            }
+          ))
+        ]
+      else if !lib.isDerivation pkg then
+        if builtins.typeOf pkg != "set" then
+          # if it is not a package, ignore it (it is probably something like overrideAttrs)
+          [ ]
+        else
+          lib.flatten (lib.mapAttrsToList (name': _: getProperties ("${name}.${name'}")) pkg)
       else
-        lib.flatten (lib.mapAttrsToList (name': _: getProperties ("${name}.${name'}")) pkg)
-    else
-      lib.flip map pkg.outputs or [ "out" ] (
-        output:
         let
-          # some packages are set to null if they aren't compatible with a platform or package set
-          maybePath = tryEval "${lib.getOutput output pkg}";
-          broken = !exists || !maybePath.success;
+          maybePath = tryEval "${pkg}";
+          broken = !maybePath.success;
         in
-        lib.nameValuePair (if output == "out" then name else "${name}.${output}") {
-          inherit exists broken;
-          path = if !broken then maybePath.value else null;
-          drvPath = if !broken then pkg.drvPath else null;
-        }
-      );
-in
-
-listToAttrs (concatMap getProperties attrs)
+        [ (lib.nameValuePair name (pkg // { inherit exists broken; })) ];
+  in
+  listToAttrs (concatMap getProperties attrs) // { recurseForDerivations = true; }
+) (fromJSON (readFile attr-json))

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -275,5 +275,5 @@ class Report:
             )
             print_number(report.blacklisted, "blacklisted", log=skipped)
             print_number(report.failed, "failed to build")
-            print_number(report.tests, "built", what="tests", log=print)
+            print_number(report.tests, "built", what="test", log=print)
             print_number(report.built, "built", log=print)

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -116,10 +116,10 @@ class SystemReport:
                 self.blacklisted.append(attr)
             elif not attr.exists:
                 self.non_existent.append(attr)
-            elif attr.name.startswith("nixosTests."):
-                self.tests.append(attr)
             elif not attr.was_build():
                 self.failed.append(attr)
+            elif attr.is_test():
+                self.tests.append(attr)
             else:
                 self.built.append(attr)
 

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -68,32 +68,31 @@ def write_error_logs(attrs_per_system: dict[str, list[Attr]], directory: Path) -
 
             attr_name: str = f"{attr.name}-{system}"
 
-            if attr.path is not None and attr.path.exists():
+            if not attr.broken:
                 if attr.was_build():
-                    symlink_source = results.ensure().joinpath(attr_name)
+                    symlink_folder = results.ensure()
                 else:
-                    symlink_source = failed_results.ensure().joinpath(attr_name)
-                if os.path.lexists(symlink_source):
-                    symlink_source.unlink()
-                symlink_source.symlink_to(attr.path)
+                    symlink_folder = failed_results.ensure()
 
-            for path in [f"{attr.drv_path}^*", attr.path]:
-                if not path:
-                    continue
-                with logs.ensure().joinpath(attr_name + ".log").open("w+") as f:
-                    nix_log = subprocess.run(
-                        [
-                            "nix",
-                            "--extra-experimental-features",
-                            "nix-command",
-                            "log",
-                            path,
-                        ],
-                        stdout=f,
-                        check=False,
-                    )
-                    if nix_log.returncode == 0:
-                        break
+                for name, path in attr.outputs_with_name().items():
+                    symlink_source = symlink_folder.joinpath(f"{name}-{system}")
+
+                    if os.path.lexists(symlink_source):
+                        symlink_source.unlink()
+                    symlink_source.symlink_to(path)
+
+            with logs.ensure().joinpath(attr_name + ".log").open("w+") as f:
+                subprocess.run(
+                    [
+                        "nix",
+                        "--extra-experimental-features",
+                        "nix-command",
+                        "log",
+                        f"{attr.drv_path}^*",
+                    ],
+                    stdout=f,
+                    check=False,
+                )
 
 
 def _serialize_attrs(attrs: list[Attr]) -> list[str]:

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -221,7 +221,7 @@ class Review:
         if self.only_packages:
             if reviewed_commit is None:
                 self.apply_unstaged(staged)
-            elif self.checkout == CheckoutOption.MERGE:
+            elif self.checkout == CheckoutOption.COMMIT:
                 self.git_checkout(reviewed_commit)
             else:
                 self.git_merge(reviewed_commit)
@@ -246,7 +246,7 @@ class Review:
 
         if reviewed_commit is None:
             self.apply_unstaged(staged)
-        elif self.checkout == CheckoutOption.MERGE:
+        elif self.checkout == CheckoutOption.COMMIT:
             self.git_checkout(reviewed_commit)
         else:
             self.git_merge(reviewed_commit)

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -305,12 +305,9 @@ class Review:
         return nix_build(
             packages_per_system,
             args,
-            self.builddir.path,
-            self.local_system,
             self.allow,
             self.build_graph,
             self.builddir.nix_path,
-            self.nixpkgs_config,
             self.num_parallel_evals,
             self.max_memory_size,
         )

--- a/nixpkgs_review/utils.py
+++ b/nixpkgs_review/utils.py
@@ -30,10 +30,12 @@ link = color_text(34)
 
 
 def sh(
-    command: list[str], cwd: Path | str | None = None
+    command: list[str],
+    cwd: Path | str | None = None,
+    input: str | None = None,  # noqa: A002
 ) -> "subprocess.CompletedProcess[str]":
     info("$ " + shlex.join(command))
-    return subprocess.run(command, cwd=cwd, text=True, check=False)
+    return subprocess.run(command, cwd=cwd, text=True, check=False, input=input)
 
 
 def verify_commit_hash(commit: str) -> str:

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -253,7 +253,7 @@ def test_pr_github_action_eval(
             helpers.assert_built(pkg_name="pkg1", path=path)
 
 
-@patch("nixpkgs_review.review._list_packages_system")
+@patch("nixpkgs_review.review.list_packages")
 def test_pr_only_packages_does_not_trigger_an_eval(
     mock_eval: MagicMock,
     helpers: Helpers,

--- a/tests/test_rev.py
+++ b/tests/test_rev.py
@@ -43,7 +43,7 @@ def test_rev_command_without_nom(helpers: Helpers) -> None:
         helpers.assert_built(pkg_name="pkg1", path=path)
 
 
-@patch("nixpkgs_review.review._list_packages_system")
+@patch("nixpkgs_review.review.list_packages")
 def test_rev_only_packages_does_not_trigger_an_eval(
     mock_eval: MagicMock,
     helpers: Helpers,

--- a/tests/test_wip.py
+++ b/tests/test_wip.py
@@ -43,7 +43,7 @@ def test_wip_command_without_nom(
         assert "$ nix build" in captured.out
 
 
-@patch("nixpkgs_review.review._list_packages_system")
+@patch("nixpkgs_review.review.list_packages")
 def test_wip_only_packages_does_not_trigger_an_eval(
     mock_eval: MagicMock,
     helpers: Helpers,


### PR DESCRIPTION
This PR replaces all calls to `nix-env -qaP` and `nix eval` with calls to [nix-eval-jobs](https://github.com/nix-community/nix-eval-jobs). This allows the user to control the memory consumption of `nixpkgs-review` very accurately.

Each commit in this PR can be tested and reviewed individually.

With `nix-eval-jobs`, the user now has to options to control the memory usage of `nixpkgs-review`:
 - `--num-parallel-evals`: the same flag that existed before and controlled the number of parallel `nix-env` calls, is now used for the `--worker` argument to `nix-eval-jobs` (default 1)
 - `--max-memory-size`: this is passed directly to `nix-eval-jobs` and controls the amount of memory in MB, that each worker can consume (default 4096).

Due to the internals of `nix-eval-jobs`, a worker can shortly consume more memory than specified by `--max-memory-size`, if the evaluation of the current attribute is large (e.g. nixos tests). But once the evaluation of that attribute is finished, the worker restarts and the memory is freed.

The `default.nix` currently includes an unreleased `nix-eval-jobs` version, because the `--apply` flag is not released yet.

To reduce the memory usage further, the invoked `nix build` command will now receive the derivations to build directly, instead of evaluating all attributes itself again (which can also consume multiple GB of RAM).

