### PR TITLE
report: fix test plural reporting

### DIFF
--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -340,5 +340,5 @@ class Report:
             )
             print_number(report.blacklisted, "blacklisted", log=skipped)
             print_number(report.failed, "failed to build")
-            print_number(report.tests, "built", what="tests", log=print)
+            print_number(report.tests, "built", what="test", log=print)
             print_number(report.built, "built", log=print)


### PR DESCRIPTION
Small typo fix. Currently the report talks about tests and testss:

```
--------- Report for 'x86_64-linux' ---------
2 testss built:
nixosTests.initrd-network-openvpn nixosTests.systemd-initrd-networkd-openvpn
```

```
--------- Report for 'x86_64-linux' ---------
1 tests built:
nixosTests.initrd-network-openvpn
```

This should take care of that. Haven't run tested it.