### PR TITLE
Add example to --systems help

### DIFF
--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -219,7 +219,7 @@ def common_flags() -> list[CommonFlag]:
             "--systems",
             type=str,
             default="current",
-            help="Nix 'systems' to evaluate and build packages for (e.g. 'x86_64-linux aarch64-darwin')",
+            help="Nix 'systems' to evaluate and build packages for (e.g. 'all' or 'x86_64-linux aarch64-darwin')",
         ),
         CommonFlag(
             "--system",


### PR DESCRIPTION
Without it, the syntax is unclear. For instance, I tried commas, and that didn't work.