### PR TITLE
Print out log directory at the end of the run

### DIFF
--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -412,7 +412,7 @@ class Review:
             # is mainly capped by available RAM
             max_workers=min(32, os.cpu_count() or 1),  # 'None' assumes IO tasks
         )
-        report.print_console(pr)
+        report.print_console(path, pr)
         report.write(path, pr)
 
         success = report.succeeded()

--- a/nixpkgs_review/utils.py
+++ b/nixpkgs_review/utils.py
@@ -26,14 +26,13 @@ def color_text(code: int, file: IO[Any] | None = None) -> Callable[[str], None]:
 warn = color_text(31, file=sys.stderr)
 info = color_text(32)
 skipped = color_text(33)
+link = color_text(34)
 
 
-def link(text: str) -> None:
-    f = color_text(34)
+def to_link(uri: str, text: str) -> str:
     if HAS_TTY:
-        f(f"\u001b]8;;{text}\u001b\\{text}\u001b]8;;\u001b\\\n")
-    else:
-        f(text)
+        return f"\u001b]8;;{uri}\u001b\\{text}\u001b]8;;\u001b\\"
+    return text
 
 
 def sh(


### PR DESCRIPTION
This is helpful when running with --no-shell where there's no "paused"
context of nix-shell to assume. The link is clickable.

(Yes, the user sees git workspace removed at the end of the run but it's
not very convenient to copy the root of nixpkgs checkout, then append
`logs` manually.)

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>
