### PR TITLE
Add tails of logs of failed packages to github comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ pass the `--post-result` flag:
 $ nixpkgs-review pr --post-result 37242
 ```
 
+If you'd like to exclude log snippets for failed builds, add the `--no-logs`
+flag:
+
+```console
+$ nixpkgs-review pr --post-result --no-logs 37242
+```
+
 Instead of posting a PR comment, nixpkgs-review can also print the report to the
 terminal using the `--print-result` flag. This flag will work for the `rev` and
 `wip` command..

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -71,6 +71,11 @@ def pr_flags(
         action="store_true",
         help="Do not render the header in the markdown report",
     )
+    pr_parser.add_argument(
+        "--no-logs",
+        action="store_true",
+        help="Do not include build error log snippets in the markdown report",
+    )
     pr_parser.set_defaults(func=pr_command)
     return pr_parser
 

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -114,6 +114,7 @@ def pr_command(args: argparse.Namespace) -> str:
                     extra_nixpkgs_config=args.extra_nixpkgs_config,
                     num_parallel_evals=args.num_parallel_evals,
                     show_header=not args.no_headers,
+                    show_logs=not args.no_logs,
                 )
                 contexts.append(
                     (pr, builddir.path, review.build_pr(pr), review.head_commit)

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -382,6 +382,10 @@ class Report:
             msg += html_pkgs_section(":white_check_mark:", report.built, "built")
 
         if self.show_logs:
+            truncated_msg = (
+                "\n---\n"
+                "WARNING: Some logs were not included in this report: there were too many."
+            )
             for system, report in self.system_reports.items():
                 if not report.failed:
                     continue
@@ -390,7 +394,8 @@ class Report:
                 full_msg += f"### Error logs: `{system}`\n"
                 full_msg += html_logs_section(get_log_dir(root), report.failed, system)
                 # if the final message won't fit a single github comment, stop
-                if len(full_msg) > MAX_GITHUB_COMMENT_LENGTH:
+                if len(full_msg) > MAX_GITHUB_COMMENT_LENGTH - len(truncated_msg):
+                    msg += truncated_msg
                     break
                 msg = full_msg
 

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -1,6 +1,7 @@
 import functools
 import json
 import os
+import re
 import socket
 import subprocess
 from collections.abc import Callable
@@ -79,10 +80,18 @@ def get_file_tail(file: Path, lines: int = 20) -> str:
         return ""
 
 
+def remove_ansi_escape_sequences(text: str) -> str:
+    """Remove ANSI escape sequences from a string."""
+    ansi_escape_pattern = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+    return ansi_escape_pattern.sub("", text)
+
+
 def html_logs_section(logs_dir: Path, packages: list[Attr], system: str) -> str:
     res = ""
     for pkg in packages:
-        tail = get_file_tail(logs_dir / get_log_filename(pkg, system))
+        tail = remove_ansi_escape_sequences(
+            get_file_tail(logs_dir / get_log_filename(pkg, system))
+        )
         if tail:
             res += f"<details>\n<summary>{pkg.name}</summary>\n<pre>{tail}</pre>\n</details>\n"
     return res

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -95,8 +95,9 @@ def html_logs_section(logs_dir: Path, packages: list[Attr], system: str) -> str:
         if tail:
             if not res:
                 res = "\n---\n"
-                res += f"### Error logs: `{system}`\n"
+                res += f"<details>\n<summary>Error logs: `{system}`</summary>\n"
             res += f"<details>\n<summary>{pkg.name}</summary>\n<pre>{tail}</pre>\n</details>\n"
+    res += "</details>\n"
     return res
 
 

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -93,6 +93,9 @@ def html_logs_section(logs_dir: Path, packages: list[Attr], system: str) -> str:
             get_file_tail(logs_dir / get_log_filename(pkg, system))
         )
         if tail:
+            if not res:
+                res = "\n---\n"
+                res += f"### Error logs: `{system}`\n"
             res += f"<details>\n<summary>{pkg.name}</summary>\n<pre>{tail}</pre>\n</details>\n"
     return res
 
@@ -399,8 +402,6 @@ class Report:
                 if not report.failed:
                     continue
                 full_msg = msg
-                full_msg += "\n---\n"
-                full_msg += f"### Error logs: `{system}`\n"
                 full_msg += html_logs_section(get_log_dir(root), report.failed, system)
                 # if the final message won't fit a single github comment, stop
                 if len(full_msg) > MAX_GITHUB_COMMENT_LENGTH - len(truncated_msg):

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -112,6 +112,7 @@ class Review:
         sandbox: bool = False,
         num_parallel_evals: int = 1,
         show_header: bool = True,
+        show_logs: bool = False,
     ) -> None:
         if skip_packages_regex is None:
             skip_packages_regex = []
@@ -149,6 +150,7 @@ class Review:
         self.extra_nixpkgs_config = extra_nixpkgs_config
         self.num_parallel_evals = num_parallel_evals
         self.show_header = show_header
+        self.show_logs = show_logs
         self.head_commit: str | None = None
 
     def _process_aliases_for_systems(self, system: str) -> set[str]:
@@ -412,6 +414,7 @@ class Review:
             skip_packages=self.skip_packages,
             skip_packages_regex=self.skip_packages_regex,
             show_header=self.show_header,
+            show_logs=self.show_logs,
             # we don't use self.num_parallel_evals here since its choice
             # is mainly capped by available RAM
             max_workers=min(32, os.cpu_count() or 1),  # 'None' assumes IO tasks
@@ -422,7 +425,7 @@ class Review:
         success = report.succeeded()
 
         if pr and post_result:
-            self.github_client.comment_issue(pr, report.markdown(pr))
+            self.github_client.comment_issue(pr, report.markdown(path, pr))
 
         if pr and approve_pr and success:
             self.github_client.approve_pr(
@@ -431,7 +434,7 @@ class Review:
             )
 
         if print_result:
-            print(report.markdown(pr))
+            print(report.markdown(path, pr))
 
         if not self.no_shell:
             nix_shell(


### PR DESCRIPTION
Snippets will be hidden under dropdown sections so as not to clutter UI.
Snippets are limited to 20 lines, and if too many logs are generated,
the report is truncated so that it fits into a single github comment.

Related: #308