### PR TITLE
add GITHUB_TOKEN_CMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,11 +261,12 @@ for detailed instructions. For posting generated reports, ensure the token is
 granted the `public_repo` scope.
 
 **Supplying the Token** You can provide your token to Nixpkgs-review using
-either the `GITHUB_TOKEN` environment variable or the `--token` parameter of the
-`pr` subcommand. Examples:
+either the `GITHUB_TOKEN` / `GITHUB_TOKEN_CMD` environment variable or the
+`--token` parameter of the `pr` subcommand. Examples:
 
 ```console
 $ GITHUB_TOKEN=ghp_WAI7vpi9wVHbxPOA185NwWvaMawDuCnMGc3E nixpkgs-review pr 37244 --post-result
+$ GITHUB_TOKEN_CMD="pass github-token" nixpkgs-review pr 37244 --post-result
 $ nixpkgs-review pr 37244 --token ghp_WAI7vpi9wVHbxPOA185NwWvaMawDuCnMGc3E --post-result
 ```
 

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -144,10 +144,13 @@ def read_github_token() -> str | None:
     token = os.environ.get("GITHUB_OAUTH_TOKEN", os.environ.get("GITHUB_TOKEN"))
     if token:
         return token
+    token_cmds = []
+    if "GITHUB_TOKEN_CMD" in os.environ:
+        token_cmds.append(os.environ.get("GITHUB_TOKEN_CMD").split())
     if which("gh"):
-        r = subprocess.run(
-            ["gh", "auth", "token"], stdout=subprocess.PIPE, text=True, check=False
-        )
+        token_cmds.append(["gh", "auth", "token"])
+    for token_cmd in token_cmds:
+        r = subprocess.run(token_cmd, stdout=subprocess.PIPE, text=True, check=False)
         if r.returncode == 0:
             return r.stdout.strip()
     return None


### PR DESCRIPTION
This environment variable can be used to specify a command which should return the token. 

This can for example be globally defined to a public command which would ask a password manager to provide this secret, eg. `pass github-token` / `rbw get github-token`