### PR TITLE
report.py: add commit to output JSON

### DIFF
--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -337,6 +337,7 @@ class Report:
             {
                 "systems": list(self.system_reports.keys()),
                 "pr": pr,
+                "commit": self.commit,
                 "checkout": self.checkout,
                 "extra-nixpkgs-config": self.extra_nixpkgs_config,
                 "only_packages": list(self.only_packages),


### PR DESCRIPTION
The commit info is right there anyways, and it'd be useful for me to have it in the JSON format.