### PR TITLE
Add --pr-json flag

### DIFF
--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import os
 import re
 import subprocess
@@ -30,6 +31,14 @@ def regex_type(s: str) -> Pattern[str]:
         return re.compile(s)
     except re.error as e:
         msg = f"'{s}' is not a valid regex: {e}"
+        raise argparse.ArgumentTypeError(msg) from e
+
+
+def json_type(s: str) -> Any:
+    try:
+        return json.loads(s)
+    except json.JSONDecodeError as e:
+        msg = f"'{s}' is not a valid JSON object: {e}"
         raise argparse.ArgumentTypeError(msg) from e
 
 
@@ -80,6 +89,13 @@ def pr_flags(
         "--no-pr-info",
         action="store_true",
         help="Do not show pull request description and diff before building",
+    )
+    pr_parser.add_argument(
+        "--pr-json",
+        type=json_type,
+        action="append",
+        default=[],
+        help="The pull request JSON data returned by the /repos/{owner}/{repo}/pulls/{pull_number} endpoint of the GitHub REST API. Useful if multiple nixpkgs-review instances should operate on the exact same PR commits. If used, needs to be specified separately for each PR.",
     )
     pr_parser.set_defaults(func=pr_command)
     return pr_parser

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -116,6 +116,7 @@ class Review:
         show_header: bool = True,
         show_logs: bool = False,
         show_pr_info: bool = True,
+        pr_object: dict | None = None,
     ) -> None:
         if skip_packages_regex is None:
             skip_packages_regex = []
@@ -156,6 +157,7 @@ class Review:
         self.show_logs = show_logs
         self.show_pr_info = show_pr_info
         self.head_commit: str | None = None
+        self.pr_object = pr_object
 
     def _process_aliases_for_systems(self, system: str) -> set[str]:
         match system:
@@ -412,7 +414,7 @@ class Review:
         )
 
     def build_pr(self, pr_number: int) -> dict[System, list[Attr]]:
-        pr = self.github_client.pull_request(pr_number)
+        pr = self.pr_object or self.github_client.pull_request(pr_number)
         self.head_commit = pr["head"]["sha"]
 
         if self.show_pr_info:


### PR DESCRIPTION
This would allow tools like [nixpkgs-review-gha](https://github.com/Defelo/nixpkgs-review-gha), which start multiple instances of nixpkgs-review on different machines and combine their results, to ensure that all instances operate on the same PR commits, even if someone pushes to the PR branch while some instances are already running and others are still starting.

The idea is to fetch the PR data via the `pulls/{number}` endpoint once and provide the resulting JSON object via the ~~`NIXPKGS_REVIEW_PULL_REQUEST_JSON` environment variable~~ `--pr-json` flag to all nixpkgs-review instances. This ensures that no API calls to the `pulls/{number}` endpoint are made at all by nixpkgs-review.

See https://github.com/Defelo/nixpkgs-review-gha/pull/31 for the nixpkgs-review-gha feature for which this would be useful.
