### PR TITLE
fix(github): handle expired artifacts with custom exception

### DIFF
--- a/nixpkgs_review/errors.py
+++ b/nixpkgs_review/errors.py
@@ -1,2 +1,6 @@
 class NixpkgsReviewError(Exception):
     """Base class for exceptions in this module."""
+
+
+class ArtifactExpiredError(NixpkgsReviewError):
+    """Raised when GitHub artifacts have expired or been removed."""

--- a/nixpkgs_review/github.py
+++ b/nixpkgs_review/github.py
@@ -7,8 +7,10 @@ import urllib.request
 import zipfile
 from http.client import HTTPMessage
 from pathlib import Path
+from textwrap import dedent
 from typing import IO, Any, override
 
+from .errors import ArtifactExpiredError
 from .utils import System, warn
 
 
@@ -132,6 +134,13 @@ class GithubClient:
             if e.code == 302:
                 new_url = e.headers["Location"]
                 # Handle the new URL as needed
+            elif e.code == 410:
+                msg = dedent(f"""
+                GitHub artifact {workflow_id} has expired or been removed
+                    * try passing --eval local
+                    * try re-running GitHub CI
+                """)
+                raise ArtifactExpiredError(msg) from e
             else:
                 raise
         else:


### PR DESCRIPTION
Throw a custom exception when we a get 410 on fetching CI results and handle accordingly in the review process to fallback to local evaluation. 

Closes https://github.com/Mic92/nixpkgs-review/issues/476

Dependent on https://github.com/Mic92/nixpkgs-review/pull/545 for CI, pulled these changes into separate branch so it doesn't hold that one up. 

---------------------------------------------------

Just saw this in the associated issue

> We should treat 410 the same way as 404.

Should i make the exception raised on `404`, as well? My understanding was that 404 waits for a retry loop so that you can wait for an evaluation to finish. But, here we had an evaluation that did finish and we know it won't because it just expired so we just force a local retry. 