### PR TITLE
Correctly report failed tests as failed

### DIFF
--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -247,10 +247,10 @@ class SystemReport:
                 self.blacklisted.append(attr)
             elif not attr.exists:
                 self.non_existent.append(attr)
-            elif attr.name.startswith("nixosTests."):
-                self.tests.append(attr)
             elif not attr.was_build():
                 self.failed.append(attr)
+            elif attr.name.startswith("nixosTests."):
+                self.tests.append(attr)
             else:
                 self.built.append(attr)
 


### PR DESCRIPTION
Previously, packages in `nixosTests` have always been added to the `tests` list (which is shown as `:white_check_mark: 1 test built:` in the markdown report), regardless of whether the test succeeded or failed.

This puts all failed packages into the `failed` list and only the tests that succeeded into the `tests` list.