### PR TITLE
Force local evaluation when a non-empy --extra-nixpkgs-config is provided

### DIFF
--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -425,6 +425,16 @@ class Review:
             self._display_pr_info(pr, pr_number)
 
         packages_per_system: dict[System, set[str]] | None = None
+
+        # GHA evaluation only evaluates nixpkgs with an empty config.
+        # Its results should not be used when a non-default nixpkgs config is requested
+        normalized_config = self.extra_nixpkgs_config.replace(" ", "")
+        if self.use_github_eval and (normalized_config != "{}"):
+            print(
+                "Non-default --extra-nixpkgs-config provided. Falling back to local evaluation"
+            )
+            self.use_github_eval = False
+
         if self.use_github_eval:
             assert all(system in PLATFORMS for system in self.systems)
             print("-> Fetching eval results from GitHub actions")


### PR DESCRIPTION
When the user provides a non-empty `--extra-nixpkgs-config`, the evaluation results from the GitHub action might not be valid.

In such cases, we should force local evaluation.
For instance, when `--extra-nixpkgs-config "{ allowUnfree = true; cudaSupport = true; }"` is provided, `nixpkgs-review` does not rebuild the correct package set.

cc @prusnak


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub-based evaluation is now automatically skipped when a non-default nixpkgs config is supplied via --extra-nixpkgs-config.
  * A clear message is shown to indicate fallback to local evaluation.
  * Ensures evaluation uses the specified custom configuration.
  * Default behavior unchanged when the default (empty) config is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->