### PR TITLE
Add support for a custom cache directory via `NIXPKGS_REVIEW_CACHE_DIR`

### DIFF
--- a/nixpkgs_review/builddir.py
+++ b/nixpkgs_review/builddir.py
@@ -29,16 +29,20 @@ class DisableKeyboardInterrupt:
 
 
 def create_cache_directory(name: str) -> Union[Path, "TemporaryDirectory[str]"]:
-    xdg_cache_raw = os.environ.get("XDG_CACHE_HOME")
-    if xdg_cache_raw is not None:
-        xdg_cache = Path(xdg_cache_raw)
+    app_cache_dir = os.environ.get("NIXPKGS_REVIEW_CACHE_DIR")
+    if app_cache_dir is not None:
+        xdg_cache = Path(app_cache_dir)
     else:
-        home = os.environ.get("HOME", None)
-        if home is None:
-            # we are in a temporary directory
-            return TemporaryDirectory()
+        xdg_cache_raw = os.environ.get("XDG_CACHE_HOME")
+        if xdg_cache_raw is not None:
+            xdg_cache = Path(xdg_cache_raw)
+        else:
+            home = os.environ.get("HOME", None)
+            if home is None:
+                # we are in a temporary directory
+                return TemporaryDirectory()
 
-        xdg_cache = Path(home).joinpath(".cache")
+            xdg_cache = Path(home).joinpath(".cache")
 
     # There is no guarantee that environment variables are set to absolute paths.
     xdg_cache = xdg_cache.absolute()


### PR DESCRIPTION
Closes https://github.com/Mic92/nixpkgs-review/issues/555.

The priority order goes:

1. `$NIXPKGS_REVIEW_CACHE_DIR` if set
2. `$XDG_CACHE_HOME` if set
3. `$HOME/.cache` if `$HOME` is set
4. `tempfile.TemporaryDirectory()` as a last resort.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Allow overriding the cache directory location via an environment variable for more flexible setup.

* **Improvements**
  * Preserves sensible fallbacks: uses XDG cache location when available, otherwise the user’s home cache; falls back to a temporary directory if neither is set.
  * Ensures the resolved cache path is absolute and continues creating unique per-name cache directories as before.
  * No changes to the public interface or usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->