### PR TITLE
Refactor eval type choice logic

### DIFF
--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -40,25 +40,10 @@ def parse_pr_numbers(number_args: list[str]) -> list[int]:
 
 def pr_command(args: argparse.Namespace) -> str:
     prs: list[int] = parse_pr_numbers(args.number)
-    match args.eval:
-        case "ofborg":
-            warn("Warning: `--eval=ofborg` is deprecated. Use `--eval=github` instead.")
-            args.eval = "github"
-        case "auto":
-            if args.token:
-                args.eval = "github"
-            else:
-                if not args.package:
-                    warn(
-                        "No GitHub token provided via GITHUB_TOKEN variable. Falling back to local evaluation.\n"
-                        "Tip: Install the `gh` command line tool and run `gh auth login` to authenticate."
-                    )
-                args.eval = "local"
-        case "github":
-            if not args.token:
-                warn("No GitHub token provided")
-                sys.exit(1)
-    use_github_eval = args.eval == "github"
+    if args.eval == "ofborg":
+        warn("Warning: `--eval=ofborg` is deprecated. Use `--eval=github` instead.")
+        args.eval = "github"
+
     checkout_option = (
         CheckoutOption.MERGE if args.checkout == "merge" else CheckoutOption.COMMIT
     )
@@ -116,7 +101,7 @@ def pr_command(args: argparse.Namespace) -> str:
                     run=args.run,
                     remote=args.remote,
                     api_token=args.token,
-                    use_github_eval=use_github_eval,
+                    eval_type=args.eval,
                     only_packages=set(args.package),
                     additional_packages=set(args.additional_package),
                     package_regexes=args.package_regex,


### PR DESCRIPTION
This PR addresses https://github.com/Mic92/nixpkgs-review/pull/556#issuecomment-3242012801.

It introduces the following new behavior (the rest should remain the same as before):

> A user can now force the github evaluation fetching even if `--extra-nixpkgs-config` is provided, by specifying `--eval github`

In #556, I forced local evaluation in this case, but some users wanted to be able to use the GitHub eval results even though they might be _wrong_.


To implement this, I centralized all the `--eval` handling logic in `review.py`.
Feel free to suggest another way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Explicit evaluation modes added: local, auto, github selectable via a single option.
  - Authenticated GitHub-based evaluation supported when an API token is provided.

- Refactor
  - Simplified evaluation selection; deprecated "ofborg" now warns and maps to "github".
  - Auto mode falls back to local when authentication or compatible configs are missing.
  - GitHub mode enforces token requirement and provides clearer warnings and fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->