### PR TITLE
Support --include-pr to merge additional PR into reviewed worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,16 @@ either locally or through the remote builder protocol.
 $ nixpkgs-review pr --systems aarch64-linux 98734
 ```
 
+## Review changes with additional PRs included
+
+Sometimes a pull request depends on changes in another pull request to pass. To
+merge additional pull requests when reviewing a pull request, use the
+`--include-pr` flag multiple times:
+
+```console
+$ nixpkgs-review pr 12345 --include-pr 67890 --include-pr 98734
+```
+
 ## Review changes inside sandbox [EXPERIMENTAL]
 
 The `--sandbox` flag setups a sandbox using

--- a/README.md
+++ b/README.md
@@ -456,6 +456,16 @@ either locally or through the remote builder protocol.
 $ nixpkgs-review pr --systems aarch64-linux 98734
 ```
 
+## Review changes with additional PRs included
+
+Sometimes a pull request depends on changes in another pull request to pass. To
+merge additional pull requests when reviewing a pull request, use the
+`--include-pr` flag multiple times:
+
+```console
+$ nixpkgs-review pr 12345 --include-pr 67890 --include-pr 98734
+```
+
 ## Review changes inside sandbox [EXPERIMENTAL]
 
 The `--sandbox` flag setups a sandbox using

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -109,6 +109,12 @@ def pr_flags(
         default=[],
         help="The pull request JSON data returned by the /repos/{owner}/{repo}/pulls/{pull_number} endpoint of the GitHub REST API. Useful if multiple nixpkgs-review instances should operate on the exact same PR commits. If used, needs to be specified separately for each PR.",
     )
+    pr_parser.add_argument(
+        "--include-pr",
+        action="append",
+        default=[],
+        help="Additional pull request to merge into the reviewed worktree. Can be passed multiple times.",
+    )
     pr_parser.set_defaults(func=pr_command)
     return pr_parser
 

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -44,6 +44,17 @@ def parse_pr_numbers(number_args: list[str]) -> list[int]:
     return prs
 
 
+def _dedupe_pr_numbers(prs: list[int]) -> list[int]:
+    deduped: list[int] = []
+    seen: set[int] = set()
+    for pr in prs:
+        if pr in seen:
+            continue
+        seen.add(pr)
+        deduped.append(pr)
+    return deduped
+
+
 def _validate_pr_json(args: argparse.Namespace, prs: list[int]) -> dict[int, Any]:
     pr_objects: dict[int, Any] = {}
     for obj in args.pr_json:
@@ -72,6 +83,7 @@ def _handle_deprecated_args(args: argparse.Namespace) -> None:
 
 def pr_command(args: argparse.Namespace) -> str:
     prs: list[int] = parse_pr_numbers(args.number)
+    included_prs = _dedupe_pr_numbers(parse_pr_numbers(args.include_pr))
     _handle_deprecated_args(args)
 
     checkout_option = CheckoutOption[args.checkout.upper()]
@@ -128,6 +140,11 @@ def pr_command(args: argparse.Namespace) -> str:
                         show_header=not args.no_headers,
                         show_logs=not args.no_logs,
                         show_pr_info=not args.no_pr_info,
+                        included_prs=[
+                            included_pr
+                            for included_pr in included_prs
+                            if included_pr != pr
+                        ],
                     ),
                     shell_options=ShellOptions(
                         no_shell=args.no_shell,

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -72,6 +72,7 @@ def _handle_deprecated_args(args: argparse.Namespace) -> None:
 
 def pr_command(args: argparse.Namespace) -> str:
     prs: list[int] = parse_pr_numbers(args.number)
+    included_prs = list(dict.fromkeys(parse_pr_numbers(args.include_pr)))
     _handle_deprecated_args(args)
 
     checkout_option = CheckoutOption[args.checkout.upper()]
@@ -128,6 +129,7 @@ def pr_command(args: argparse.Namespace) -> str:
                         show_header=not args.no_headers,
                         show_logs=not args.no_logs,
                         show_pr_info=not args.no_pr_info,
+                        included_prs=[p for p in included_prs if p != pr],
                     ),
                     shell_options=ShellOptions(
                         no_shell=args.no_shell,

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -7,7 +7,7 @@ import re
 import socket
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
 from .utils import (
@@ -317,6 +317,7 @@ class ReportOptions:
 
     extra_nixpkgs_config: str = "{ }"
     checkout: Literal["merge", "commit"] = "merge"
+    included_prs: list[int] = field(default_factory=list)
     show_header: bool = True
     show_logs: bool = False
     max_workers: int | None = 1
@@ -340,6 +341,7 @@ class Report:
         self.checkout = options.checkout
         self.package_filter = package_filter
         self.pkgs = options.pkgs
+        self.included_prs = options.included_prs
 
         self.extra_nixpkgs_config = (
             options.extra_nixpkgs_config
@@ -375,6 +377,7 @@ class Report:
                 "pr": pr,
                 "commit": self.commit,
                 "checkout": self.checkout,
+                "included_prs": self.included_prs,
                 "extra-nixpkgs-config": self.extra_nixpkgs_config,
                 "only_packages": list(self.package_filter.only_packages),
                 "additional_packages": list(self.package_filter.additional_packages),
@@ -403,6 +406,8 @@ class Report:
             cmd += f" --extra-nixpkgs-config '{self.extra_nixpkgs_config}'"
         if self.checkout != "merge":
             cmd += f" --checkout {self.checkout}"
+        for included_pr in self.included_prs:
+            cmd += f" --include-pr {included_pr}"
         if self.pkgs:
             cmd += f" --pkgs={self.pkgs}"
 

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -7,7 +7,7 @@ import re
 import socket
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 
 from .utils import (
@@ -318,6 +318,7 @@ class ReportOptions:
 
     extra_nixpkgs_config: str = "{ }"
     checkout: Literal["merge", "commit"] = "merge"
+    included_prs: list[int] = field(default_factory=list)
     show_header: bool = True
     show_logs: bool = False
     max_workers: int | None = 1
@@ -341,6 +342,7 @@ class Report:
         self.checkout = options.checkout
         self.package_filter = package_filter
         self.pkgs = options.pkgs
+        self.included_prs = options.included_prs
 
         self.extra_nixpkgs_config = (
             options.extra_nixpkgs_config
@@ -376,6 +378,7 @@ class Report:
                 "pr": pr,
                 "commit": self.commit,
                 "checkout": self.checkout,
+                "included_prs": self.included_prs,
                 "extra-nixpkgs-config": self.extra_nixpkgs_config,
                 "only_packages": list(self.package_filter.only_packages),
                 "additional_packages": list(self.package_filter.additional_packages),
@@ -404,6 +407,8 @@ class Report:
             cmd += f" --extra-nixpkgs-config '{self.extra_nixpkgs_config}'"
         if self.checkout != "merge":
             cmd += f" --checkout {self.checkout}"
+        for included_pr in self.included_prs:
+            cmd += f" --include-pr {included_pr}"
         if self.pkgs:
             cmd += f" --pkgs={self.pkgs}"
 

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -83,6 +83,7 @@ class ReviewConfig:
     show_header: bool = True
     show_logs: bool = False
     show_pr_info: bool = True
+    included_prs: list[int] = field(default_factory=list)
 
 
 def _prefix_with_pkgs(packages: set[str], pkgs: str | None) -> set[str]:
@@ -330,10 +331,11 @@ class Review:
 
         print(f"{'=' * 80}\n")
 
-    def git_merge(self, commit: str) -> None:
-        res = git.run(
-            ["merge", "--no-commit", "--no-ff", commit], cwd=self.worktree_dir()
-        )
+    def git_merge(self, commit: str, *, create_commit: bool = False) -> None:
+        args = ["merge", "--no-ff"]
+        args.extend(["--no-edit"] if create_commit else ["--no-commit"])
+        args.append(commit)
+        res = git.run(args, cwd=self.worktree_dir())
         if res.returncode != 0:
             msg = f"Failed to merge {commit} into {self.worktree_dir()}. git merge failed with exit code {res.returncode}"
             raise NixpkgsReviewError(msg)
@@ -373,6 +375,59 @@ class Review:
         *,
         staged: bool = False,
     ) -> dict[System, list[Attr]]:
+        self._checkout_build_state(
+            base_commit,
+            head_commit,
+            merge_commit,
+            staged=staged,
+        )
+
+        changed_attrs = {
+            system: _prefix_with_pkgs(
+                set(self.package_filter.only_packages), self.build_config.pkgs
+            )
+            for system in self.systems
+        }
+
+        return self.build(changed_attrs, self.shell_options.build_args)
+
+    def _merge_included_prs(self) -> None:
+        for included_pr in self.review_config.included_prs:
+            print(f"Including changes from PR #{included_pr}...")
+            pr = self.github_client.pull_request(included_pr)
+            [pr_rev] = fetch_refs(
+                self.review_config.remote,
+                pr["head"]["sha"],
+                shallow_depth=2,
+            )
+            self.git_merge(pr_rev, create_commit=True)
+
+    def _checkout_eval_state(
+        self,
+        head_commit: str | None,
+        merge_commit: str | None = None,
+        *,
+        staged: bool = False,
+    ) -> None:
+        if head_commit is None:
+            self.apply_unstaged(staged=staged)
+        elif merge_commit:
+            self.git_checkout(merge_commit)
+        else:
+            self.git_merge(
+                head_commit,
+                create_commit=bool(self.review_config.included_prs),
+            )
+        self._merge_included_prs()
+
+    def _checkout_build_state(
+        self,
+        base_commit: str,
+        head_commit: str | None,
+        merge_commit: str | None = None,
+        *,
+        staged: bool = False,
+    ) -> None:
         if head_commit is None:
             self.apply_unstaged(staged=staged)
         else:
@@ -383,18 +438,13 @@ class Review:
                     if merge_commit:
                         self.git_checkout(merge_commit)
                     else:
-                        self.git_merge(head_commit)
+                        self.git_merge(
+                            head_commit,
+                            create_commit=bool(self.review_config.included_prs),
+                        )
                 case CheckoutOption.BASE:
                     self.git_checkout(base_commit)
-
-        changed_attrs = {
-            system: _prefix_with_pkgs(
-                set(self.package_filter.only_packages), self.build_config.pkgs
-            )
-            for system in self.systems
-        }
-
-        return self.build(changed_attrs, self.shell_options.build_args)
+        self._merge_included_prs()
 
     def build_commit(
         self,
@@ -408,6 +458,7 @@ class Review:
         Review a local git commit
         """
         self.git_worktree(base_commit)
+
         changed_attrs: dict[System, set[str]] = {}
 
         if self.package_filter.only_packages:
@@ -424,12 +475,7 @@ class Review:
             self.build_config.pkgs,
         )
 
-        if head_commit is None:
-            self.apply_unstaged(staged=staged)
-        elif merge_commit:
-            self.git_checkout(merge_commit)
-        else:
-            self.git_merge(head_commit)
+        self._checkout_eval_state(head_commit, merge_commit, staged=staged)
 
         merged_packages: dict[System, list[Package]] = list_packages(
             self.builddir.nix_path,
@@ -455,10 +501,8 @@ class Review:
 
             changed_attrs[system] = {p.attr_path for p in changed_pkgs}
 
-        if head_commit and self.review_config.checkout == CheckoutOption.COMMIT:
-            self.git_checkout(head_commit)
-        elif base_commit and self.review_config.checkout == CheckoutOption.BASE:
-            self.git_checkout(base_commit)
+        if head_commit and self.review_config.checkout != CheckoutOption.MERGE:
+            self._checkout_build_state(base_commit, head_commit, merge_commit)
 
         return self.build(changed_attrs, self.shell_options.build_args)
 
@@ -557,7 +601,10 @@ class Review:
                     self.git_worktree(merge_rev)
                 else:
                     self.git_worktree(base_rev)
-                    self.git_merge(head_rev)
+                    self.git_merge(
+                        head_rev,
+                        create_commit=bool(self.review_config.included_prs),
+                    )
             case CheckoutOption.COMMIT:
                 self.git_worktree(head_rev)
             case CheckoutOption.BASE:
@@ -598,6 +645,7 @@ class Review:
             return self.build_commit(base_rev, head_rev, merge_rev)
 
         self._checkout_pr_revision(base_rev, head_rev, merge_rev)
+        self._merge_included_prs()
 
         for system in list(packages_per_system.keys()):
             if system not in self.systems:
@@ -624,6 +672,7 @@ class Review:
             ReportOptions(
                 extra_nixpkgs_config=self.review_config.extra_nixpkgs_config,
                 checkout=self.review_config.checkout.name.lower(),  # type: ignore[arg-type]
+                included_prs=self.review_config.included_prs,
                 show_header=self.review_config.show_header,
                 show_logs=self.review_config.show_logs,
                 max_workers=min(32, os.cpu_count() or 1),

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -91,6 +91,7 @@ class ReviewConfig:
     show_header: bool = True
     show_logs: bool = False
     show_pr_info: bool = True
+    included_prs: list[int] = field(default_factory=list)
 
 
 def _prefix_with_pkgs(packages: set[str], pkgs: str | None) -> set[str]:
@@ -182,6 +183,7 @@ class Review:
         self.build_config = build_config
         self.shell_options = shell_options
         self.head_commit: str | None = None
+        self._included_pr_revs: list[str] | None = None
 
     @property
     def _use_github_eval(self) -> bool:
@@ -337,18 +339,40 @@ class Review:
         print(f"{'=' * 80}\n")
 
     def git_merge(self, commit: str) -> None:
+        # Commit the merge so further merges (--include-pr) can stack on top;
+        # the worktree is throwaway, so never sign.
         res = git.run(
-            ["merge", "--no-commit", "--no-ff", commit], cwd=self.worktree_dir()
+            ["merge", "--no-ff", "--no-edit", "--no-gpg-sign", commit],
+            cwd=self.worktree_dir(),
         )
         if res.returncode != 0:
             msg = f"Failed to merge {commit} into {self.worktree_dir()}. git merge failed with exit code {res.returncode}"
             raise NixpkgsReviewError(msg)
+
+    def _merge_included_prs(self) -> None:
+        """Included PRs are treated as part of the base: they are merged into
+        every state we evaluate or build so only the reviewed PR shows up as
+        a change."""
+        if not self.review_config.included_prs:
+            return
+        if self._included_pr_revs is None:
+            heads = [
+                self.github_client.pull_request(n)["head"]["sha"]
+                for n in self.review_config.included_prs
+            ]
+            self._included_pr_revs = fetch_refs(self.review_config.remote, *heads)
+        for n, rev in zip(
+            self.review_config.included_prs, self._included_pr_revs, strict=True
+        ):
+            info(f"Merging included PR #{n} ({rev})")
+            self.git_merge(rev)
 
     def git_checkout(self, commit: str) -> None:
         res = git.run(["checkout", commit], cwd=self.worktree_dir())
         if res.returncode != 0:
             msg = f"Failed to checkout {commit} in {self.worktree_dir()}. git checkout failed with exit code {res.returncode}"
             raise NixpkgsReviewError(msg)
+        self._merge_included_prs()
 
     def apply_unstaged(self, *, staged: bool = False) -> None:
         args = [
@@ -473,6 +497,7 @@ class Review:
         if res.returncode != 0:
             msg = f"Failed to add worktree for {commit} in {self.worktree_dir()}. git worktree failed with exit code {res.returncode}"
             raise NixpkgsReviewError(msg)
+        self._merge_included_prs()
 
     def build(
         self, packages_per_system: dict[System, set[str]], args: str
@@ -646,6 +671,7 @@ class Review:
             ReportOptions(
                 extra_nixpkgs_config=self.review_config.extra_nixpkgs_config,
                 checkout=self.review_config.checkout.name.lower(),  # type: ignore[arg-type]
+                included_prs=self.review_config.included_prs,
                 show_header=self.review_config.show_header,
                 show_logs=self.review_config.show_logs,
                 max_workers=min(32, os.cpu_count() or 1),

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import zipfile
 from http.client import HTTPMessage
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, Mock, mock_open, patch
 from urllib.error import HTTPError
@@ -13,6 +14,7 @@ from urllib.error import HTTPError
 import pytest
 
 from nixpkgs_review.cli import main
+from nixpkgs_review.cli.pr import _dedupe_pr_numbers
 from nixpkgs_review.utils import nix_nom_tool
 
 if TYPE_CHECKING:
@@ -98,6 +100,38 @@ def setup_repo(nixpkgs: Nixpkgs) -> tuple[str, str, str]:
     head = git_rev_parse("HEAD^2")
     merge = git_rev_parse("HEAD")
     return base, head, merge
+
+
+def setup_repo_with_included_pr(nixpkgs: Nixpkgs) -> tuple[str, str, str, str]:
+    subprocess.run(["git", "checkout", "-b", "pull/2/head"], check=True)
+    nixpkgs.path.joinpath("pkg2.txt").write_text("bar")
+    subprocess.run(["git", "add", "pkg2.txt"], check=True)
+    subprocess.run(["git", "commit", "-m", "included-change"], check=True)
+    subprocess.run(["git", "push", str(nixpkgs.remote), "pull/2/head"], check=True)
+    included_head = git_rev_parse("HEAD")
+
+    subprocess.run(["git", "checkout", "-b", "pull/1/head", "master"], check=True)
+    default_nix = nixpkgs.path.joinpath("default.nix")
+    default_nix.write_text(
+        default_nix.read_text().replace(
+            "cat ${./pkg1.txt} > $out",
+            "cat ${./pkg1.txt} ${./pkg2.txt} > $out",
+        )
+    )
+    subprocess.run(["git", "add", "default.nix"], check=True)
+    subprocess.run(["git", "commit", "-m", "main-change"], check=True)
+    subprocess.run(["git", "checkout", "-b", "pull/1/merge", "master"], check=True)
+    subprocess.run(["git", "merge", "--no-ff", "pull/1/head"], check=True)
+    subprocess.run(["git", "push", str(nixpkgs.remote), "pull/1/merge"], check=True)
+
+    base = git_rev_parse("HEAD^1")
+    head = git_rev_parse("HEAD^2")
+    merge = git_rev_parse("HEAD")
+    return base, head, merge, included_head
+
+
+def test_dedupe_pr_numbers_preserves_order() -> None:
+    assert _dedupe_pr_numbers([2, 3, 2, 1, 3]) == [2, 3, 1]
 
 
 @patch("nixpkgs_review.utils.shutil.which", return_value=None)
@@ -227,6 +261,54 @@ def test_pr_local_eval_without_merge_commit_sha(
             ],
         )
         helpers.assert_built(path, "pkg1")
+
+
+@patch("nixpkgs_review.http_requests.urlopen")
+def test_pr_local_eval_with_included_prs(
+    mock_urlopen: MagicMock,
+    helpers: Helpers,
+) -> None:
+    with helpers.nixpkgs() as nixpkgs:
+        base, head, merge, included_head = setup_repo_with_included_pr(nixpkgs)
+
+        main_pr = create_mock_pr_response(
+            base_rev=base,
+            head_rev=head,
+            merge_rev=merge,
+        )
+        included_pr = create_mock_pr_response(
+            pr_number=2,
+            base_rev=base,
+            head_rev=included_head,
+            merge_rev=None,
+        )
+
+        mock_urlopen.side_effect = [
+            mock_open(read_data=json.dumps(main_pr).encode())(),
+            mock_open(read_data=create_mock_diff_content().encode())(),
+            mock_open(read_data=json.dumps(included_pr).encode())(),
+        ]
+
+        path = main(
+            "nixpkgs-review",
+            [
+                "pr",
+                "1",
+                "--remote",
+                str(nixpkgs.remote),
+                "--eval",
+                "local",
+                "--run",
+                "exit 0",
+                "--include-pr",
+                "2",
+            ],
+        )
+        helpers.assert_built(path, "pkg1")
+        report = helpers.load_report(path)
+        assert report["included_prs"] == [2]
+        report_md = (Path(path) / "report.md").read_text()
+        assert "Command: `nixpkgs-review pr 1 --include-pr 2`" in report_md
 
 
 @pytest.mark.skipif(not shutil.which("bwrap"), reason="`bwrap` not found in PATH")

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import zipfile
 from http.client import HTTPMessage
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, Mock, mock_open, patch
 from urllib.error import HTTPError
@@ -98,6 +99,34 @@ def setup_repo(nixpkgs: Nixpkgs) -> tuple[str, str, str]:
     head = git_rev_parse("HEAD^2")
     merge = git_rev_parse("HEAD")
     return base, head, merge
+
+
+def setup_repo_with_included_pr(nixpkgs: Nixpkgs) -> tuple[str, str, str, str]:
+    subprocess.run(["git", "checkout", "-b", "pull/2/head"], check=True)
+    nixpkgs.path.joinpath("pkg2.txt").write_text("bar")
+    subprocess.run(["git", "add", "pkg2.txt"], check=True)
+    subprocess.run(["git", "commit", "-m", "included-change"], check=True)
+    subprocess.run(["git", "push", str(nixpkgs.remote), "pull/2/head"], check=True)
+    included_head = git_rev_parse("HEAD")
+
+    subprocess.run(["git", "checkout", "-b", "pull/1/head", "master"], check=True)
+    default_nix = nixpkgs.path.joinpath("default.nix")
+    default_nix.write_text(
+        default_nix.read_text().replace(
+            "cat ${./pkg1.txt} > $out",
+            "cat ${./pkg1.txt} ${./pkg2.txt} > $out",
+        )
+    )
+    subprocess.run(["git", "add", "default.nix"], check=True)
+    subprocess.run(["git", "commit", "-m", "main-change"], check=True)
+    subprocess.run(["git", "checkout", "-b", "pull/1/merge", "master"], check=True)
+    subprocess.run(["git", "merge", "--no-ff", "pull/1/head"], check=True)
+    subprocess.run(["git", "push", str(nixpkgs.remote), "pull/1/merge"], check=True)
+
+    base = git_rev_parse("HEAD^1")
+    head = git_rev_parse("HEAD^2")
+    merge = git_rev_parse("HEAD")
+    return base, head, merge, included_head
 
 
 @patch("nixpkgs_review.utils.shutil.which", return_value=None)
@@ -227,6 +256,71 @@ def test_pr_local_eval_without_merge_commit_sha(
             ],
         )
         helpers.assert_built(path, "pkg1")
+
+
+@patch("nixpkgs_review.http_requests.urlopen")
+def test_pr_local_eval_with_included_prs(
+    mock_urlopen: MagicMock,
+    helpers: Helpers,
+) -> None:
+    with helpers.nixpkgs() as nixpkgs:
+        base, head, merge, included_head = setup_repo_with_included_pr(nixpkgs)
+
+        # Internal merge commits must not inherit the user's signing configuration.
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(nixpkgs.path),
+                "config",
+                "commit.gpgSign",
+                "true",
+            ],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(nixpkgs.path), "config", "gpg.program", "false"],
+            check=True,
+        )
+
+        main_pr = create_mock_pr_response(
+            base_rev=base,
+            head_rev=head,
+            merge_rev=merge,
+        )
+        included_pr = create_mock_pr_response(
+            pr_number=2,
+            base_rev=base,
+            head_rev=included_head,
+            merge_rev=None,
+        )
+
+        mock_urlopen.side_effect = [
+            mock_open(read_data=json.dumps(main_pr).encode())(),
+            mock_open(read_data=create_mock_diff_content().encode())(),
+            mock_open(read_data=json.dumps(included_pr).encode())(),
+        ]
+
+        path = main(
+            "nixpkgs-review",
+            [
+                "pr",
+                "1",
+                "--remote",
+                str(nixpkgs.remote),
+                "--eval",
+                "local",
+                "--run",
+                "exit 0",
+                "--include-pr",
+                "2",
+            ],
+        )
+        helpers.assert_built(path, "pkg1")
+        report = helpers.load_report(path)
+        assert report["included_prs"] == [2]
+        report_md = (Path(path) / "report.md").read_text()
+        assert "Command: `nixpkgs-review pr 1 --include-pr 2`" in report_md
 
 
 @pytest.mark.skipif(not shutil.which("bwrap"), reason="`bwrap` not found in PATH")


### PR DESCRIPTION
Sometimes a PR can be fully validated only with another unmerged PR. In this scenario, one either has to wait for the first PR to merge, or construct an alternative test path that is not using nixpkgs-review.

This patch solves it by adding support for --include-pr option that, if used, will merge additional PRs into the worktree under test.

The final report will list the new option to avoid confusion or misleading the reader as to the final state under test.

The option can be passed multiple times to include multiple PRs. The order of merges of the requested PRs is retained.