### PR TITLE
Fix fetching of GH eval results if there are no rebuilds

### DIFF
--- a/nixpkgs_review/github.py
+++ b/nixpkgs_review/github.py
@@ -307,7 +307,7 @@ class GithubClient:
                 if artifact["name"] != "comparison":
                     continue
                 result = self._process_comparison_artifact(artifact["id"])
-                if result:
+                if result is not None:
                     return result
 
         return None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of valid but falsy evaluation results from GitHub Actions, preventing them from being skipped.
  * Ensures results like 0 or empty strings are treated as legitimate outcomes rather than ignored.
  * Improves reliability and consistency of displayed evaluation results in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->