### PR TITLE
Add --extra-nixpkgs-args

### DIFF
--- a/nixpkgs_review/builddir.py
+++ b/nixpkgs_review/builddir.py
@@ -13,6 +13,8 @@ from .utils import warn
 if TYPE_CHECKING:
     import types
 
+    from .buildenv import Buildenv
+
 
 class DisableKeyboardInterrupt:
     def __enter__(self) -> None:
@@ -60,7 +62,7 @@ def create_cache_directory(name: str) -> Path | TemporaryDirectory[str]:
 
 
 class Builddir:
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, buildenv: Buildenv) -> None:
         self.environ = os.environ.copy()
         self.directory = create_cache_directory(name)
         self._temp_directory: TemporaryDirectory[str] | None = None
@@ -75,6 +77,7 @@ class Builddir:
         self.worktree_dir = self.path / "nixpkgs"
         self.worktree_dir.mkdir()
         self._nix_path_parts = [
+            f"nixpkgs-wrapper={buildenv.nixpkgs_wrapper}",
             f"nixpkgs={self.worktree_dir}",
             f"nixpkgs-overlays={self.overlay.path}",
         ]

--- a/nixpkgs_review/buildenv.py
+++ b/nixpkgs_review/buildenv.py
@@ -4,7 +4,7 @@ import contextlib
 import os
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 from .nixpkgs import find_nixpkgs_root
 from .utils import die
@@ -14,39 +14,50 @@ if TYPE_CHECKING:
 
 
 class Buildenv:
-    def __init__(self, *, allow_aliases: bool, extra_nixpkgs_config: str) -> None:
+    def __init__(
+        self, *, allow_aliases: bool, extra_nixpkgs_config: str, extra_nixpkgs_args: str
+    ) -> None:
         if not (
             extra_nixpkgs_config.startswith("{") and extra_nixpkgs_config.endswith("}")
         ):
             msg = "--extra-nixpkgs-config must start with `{` and end with `}`"
             raise RuntimeError(msg)
+        if not (
+            extra_nixpkgs_args.startswith("{") and extra_nixpkgs_args.endswith("}")
+        ):
+            msg = "--extra-nixpkgs-args must start with `{` and end with `}`"
+            raise RuntimeError(msg)
 
-        self.nixpkgs_config = NamedTemporaryFile(suffix=".nix")  # noqa: SIM115
+        self._nixpkgs_wrapper_file = NamedTemporaryFile(suffix=".nix")  # noqa: SIM115
         self.old_cwd: Path | None = None
         self.environ: dict[str, str] | None = None
         aliases_config = "allowAliases = false;" if not allow_aliases else ""
-        config_content = f"""{{
-  allowUnfree = true;
-  allowBroken = true;
-  {aliases_config}
-  checkMeta = true;
-  ## TODO: also build packages marked as insecure
-  # allowInsecurePredicate = x: true;
-}} // {extra_nixpkgs_config}
+        config_content = f"""{{...}}@args:
+let extraArgs = {extra_nixpkgs_args};
+in import <nixpkgs> ({{
+  config = {{
+    allowUnfree = true;
+    allowBroken = true;
+    {aliases_config}
+    checkMeta = true;
+    ## TODO: also build packages marked as insecure
+    # allowInsecurePredicate = x: true;
+  }} // {extra_nixpkgs_config} // extraArgs.config or {{}} // args.config or {{}};
+}} // (removeAttrs extraArgs [ "config" ]) // (removeAttrs args [ "config" ]))
 """
-        self.nixpkgs_config.write(config_content.encode())
-        self.nixpkgs_config.flush()
+        self._nixpkgs_wrapper_file.write(config_content.encode())
+        self._nixpkgs_wrapper_file.flush()
 
-    def __enter__(self) -> Path:
+    def __enter__(self) -> Self:
         self.environ = os.environ.copy()
         self.old_cwd = Path.cwd()
+        self.nixpkgs_wrapper = Path(self._nixpkgs_wrapper_file.name)
 
         if (root := find_nixpkgs_root()) is None:
             die("Has to be executed from nixpkgs repository")
         os.chdir(root)
 
-        os.environ["NIXPKGS_CONFIG"] = self.nixpkgs_config.name
-        return Path(self.nixpkgs_config.name)
+        return self
 
     def __exit__(
         self,
@@ -62,5 +73,5 @@ class Buildenv:
             os.environ.clear()
             os.environ.update(self.environ)
 
-        if self.nixpkgs_config is not None:
-            self.nixpkgs_config.close()
+        if self._nixpkgs_wrapper_file is not None:
+            self._nixpkgs_wrapper_file.close()

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -310,6 +310,12 @@ def common_flags() -> list[CommonFlag]:
             help="Extra nixpkgs config to pass to `import <nixpkgs>`",
         ),
         CommonFlag(
+            "--extra-nixpkgs-args",
+            type=str,
+            default="{ }",
+            help="Extra nixpkgs args to pass to `import <nixpkgs>`",
+        ),
+        CommonFlag(
             "--num-eval-workers",
             type=int,
             default=None,

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -104,23 +104,24 @@ def pr_command(args: argparse.Namespace) -> str:
     builddir = None
     with (
         Buildenv(
-            allow_aliases=allow.aliases, extra_nixpkgs_config=args.extra_nixpkgs_config
-        ) as nixpkgs_config,
+            allow_aliases=allow.aliases,
+            extra_nixpkgs_config=args.extra_nixpkgs_config,
+            extra_nixpkgs_args=args.extra_nixpkgs_args,
+        ) as buildenv,
         ExitStack() as stack,
     ):
         review = None
         for pr in prs:
-            builddir = stack.enter_context(Builddir(f"pr-{pr}"))
+            builddir = stack.enter_context(Builddir(f"pr-{pr}", buildenv))
             try:
                 review = Review(
                     builddir=builddir,
                     package_filter=package_filter_from_args(args),
-                    build_config=build_config_from_args(
-                        args, allow, builddir.nix_path, nixpkgs_config
-                    ),
+                    build_config=build_config_from_args(args, allow, builddir.nix_path),
                     review_config=ReviewConfig(
                         remote=args.remote,
                         extra_nixpkgs_config=args.extra_nixpkgs_config,
+                        extra_nixpkgs_args=args.extra_nixpkgs_args,
                         systems=args.systems.split(" "),
                         api_token=args.token,
                         eval_type=args.eval,

--- a/nixpkgs_review/cli/rev.py
+++ b/nixpkgs_review/cli/rev.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from nixpkgs_review import git
 from nixpkgs_review.allow import AllowedFeatures
+from nixpkgs_review.builddir import Builddir
 from nixpkgs_review.buildenv import Buildenv
 from nixpkgs_review.review import (
     LocalRevisionTarget,
@@ -21,13 +22,15 @@ if TYPE_CHECKING:
 def rev_command(args: argparse.Namespace) -> Path:
     allow = AllowedFeatures(args.allow)
     with Buildenv(
-        allow_aliases=allow.aliases, extra_nixpkgs_config=args.extra_nixpkgs_config
-    ) as nixpkgs_config:
+        allow_aliases=allow.aliases,
+        extra_nixpkgs_config=args.extra_nixpkgs_config,
+        extra_nixpkgs_args=args.extra_nixpkgs_args,
+    ) as buildenv:
         commit = git.verify_commit_hash(args.commit)
         return review_local_revision(
-            f"rev-{commit}",
+            Builddir(f"rev-{commit}", buildenv),
             args,
-            partial(build_config_from_args, args, allow, nixpkgs_config=nixpkgs_config),
+            partial(build_config_from_args, args, allow),
             LocalRevisionTarget(
                 commit=commit,
                 action=ReviewAction(print_result=args.print_result),

--- a/nixpkgs_review/cli/wip.py
+++ b/nixpkgs_review/cli/wip.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from nixpkgs_review import git
 from nixpkgs_review.allow import AllowedFeatures
+from nixpkgs_review.builddir import Builddir
 from nixpkgs_review.buildenv import Buildenv
 from nixpkgs_review.nixpkgs import is_bare_repository
 from nixpkgs_review.review import (
@@ -23,17 +24,19 @@ if TYPE_CHECKING:
 def wip_command(args: argparse.Namespace) -> Path:
     allow = AllowedFeatures(args.allow)
     with Buildenv(
-        allow_aliases=allow.aliases, extra_nixpkgs_config=args.extra_nixpkgs_config
-    ) as nixpkgs_config:
+        allow_aliases=allow.aliases,
+        extra_nixpkgs_config=args.extra_nixpkgs_config,
+        extra_nixpkgs_args=args.extra_nixpkgs_args,
+    ) as buildenv:
         if is_bare_repository():
             die(
                 "The `wip` command requires a working tree, but the current repository "
                 "is bare. Use `nixpkgs-review pr` or `nixpkgs-review rev <commit>` instead."
             )
         return review_local_revision(
-            f"rev-{git.verify_commit_hash('HEAD')}-dirty",
+            Builddir(f"rev-{git.verify_commit_hash('HEAD')}-dirty", buildenv),
             args,
-            partial(build_config_from_args, args, allow, nixpkgs_config=nixpkgs_config),
+            partial(build_config_from_args, args, allow),
             LocalRevisionTarget(
                 staged=args.staged,
                 action=ReviewAction(print_result=args.print_result),

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -24,7 +24,6 @@ class BuildConfig:
 
     allow: AllowedFeatures
     nix_path: str
-    nixpkgs_config: Path
     num_eval_workers: int = 1
     max_memory_size: int = 4096
     pkgs: str | None = None

--- a/nixpkgs_review/nix/evalAttrs.nix
+++ b/nixpkgs_review/nix/evalAttrs.nix
@@ -7,9 +7,9 @@ with builtins;
 mapAttrs (
   system: attrs:
   let
-    pkgs = import <nixpkgs> {
+    pkgs = import <nixpkgs-wrapper> {
       inherit system;
-      config = import (getEnv "NIXPKGS_CONFIG") // {
+      config = {
         allowBroken = false;
       };
     };

--- a/nixpkgs_review/nix/listPackages.nix
+++ b/nixpkgs_review/nix/listPackages.nix
@@ -10,9 +10,8 @@ let
   forSystem =
     system:
     let
-      nixpkgs = import <nixpkgs> {
+      nixpkgs = import <nixpkgs-wrapper> {
         inherit system;
-        config = import (builtins.getEnv "NIXPKGS_CONFIG");
       };
       inherit (nixpkgs) lib;
       root = if pkgs == null then nixpkgs else lib.attrByPath (lib.splitString "." pkgs) { } nixpkgs;

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -317,6 +317,7 @@ class ReportOptions:
     """Options controlling report generation."""
 
     extra_nixpkgs_config: str = "{ }"
+    extra_nixpkgs_args: str = "{ }"
     checkout: Literal["merge", "commit"] = "merge"
     included_prs: list[int] = field(default_factory=list)
     show_header: bool = True
@@ -351,6 +352,9 @@ class Report:
             if options.extra_nixpkgs_config != "{ }"
             else None
         )
+        self.extra_nixpkgs_args = (
+            options.extra_nixpkgs_args if options.extra_nixpkgs_args != "{ }" else None
+        )
 
         reports: dict[System, SystemReport] = {}
         for system, attrs in attrs_per_system.items():
@@ -379,6 +383,7 @@ class Report:
                 "checkout": self.checkout,
                 "included_prs": self.included_prs,
                 "extra-nixpkgs-config": self.extra_nixpkgs_config,
+                "extra-nixpkgs-args": self.extra_nixpkgs_args,
                 "only_packages": list(self.package_filter.only_packages),
                 "additional_packages": list(self.package_filter.additional_packages),
                 "package_regex": [
@@ -404,6 +409,8 @@ class Report:
             cmd += f" pr {pr}"
         if self.extra_nixpkgs_config:
             cmd += f" --extra-nixpkgs-config '{self.extra_nixpkgs_config}'"
+        if self.extra_nixpkgs_args:
+            cmd += f" --extra-nixpkgs-args '{self.extra_nixpkgs_args}'"
         if self.checkout != "merge":
             cmd += f" --checkout {self.checkout}"
         for included_pr in self.included_prs:

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING, Any, Final, cast
 from urllib.error import URLError
 
 from . import git, http_requests
-from .builddir import Builddir
 from .errors import NixpkgsReviewError
 from .github import GithubClient, GitHubPullRequest
 from .nix import (
@@ -48,6 +47,7 @@ if TYPE_CHECKING:
     from re import Pattern
 
     from .allow import AllowedFeatures
+    from .builddir import Builddir
 
 # keep up to date with `supportedPlatforms`
 # https://github.com/NixOS/ofborg/blob/cf2c6712bd7342406e799110e7cd465aa250cdca/ofborg/src/outpaths.nix#L12
@@ -86,6 +86,7 @@ class ReviewConfig:
 
     remote: str
     extra_nixpkgs_config: str
+    extra_nixpkgs_args: str
     systems: list[System]
     eval_type: str = "auto"
     api_token: str | None = None
@@ -210,7 +211,10 @@ class Review:
 
         # GHA evaluation only evaluates nixpkgs with an empty config.
         # Its results might be incorrect when a non-default nixpkgs config is requested
-        if self.review_config.extra_nixpkgs_config.replace(" ", "") == "{}":
+        if (
+            self.review_config.extra_nixpkgs_config.replace(" ", "") == "{}"
+            and self.review_config.extra_nixpkgs_args.replace(" ", "") == "{}"
+        ):
             return True
 
         warn("Non-default --extra-nixpkgs-config provided.")
@@ -676,7 +680,6 @@ class Review:
         action: ReviewAction | None = None,
     ) -> bool:
         action = action or ReviewAction()
-        os.environ.pop("NIXPKGS_CONFIG", None)
         os.environ["NIXPKGS_REVIEW_ROOT"] = str(path)
         if pr:
             os.environ["PR"] = str(pr)
@@ -686,6 +689,7 @@ class Review:
             self.package_filter,
             ReportOptions(
                 extra_nixpkgs_config=self.review_config.extra_nixpkgs_config,
+                extra_nixpkgs_args=self.review_config.extra_nixpkgs_args,
                 checkout=self.review_config.checkout.name.lower(),  # type: ignore[arg-type]
                 included_prs=self.review_config.included_prs,
                 show_header=self.review_config.show_header,
@@ -1010,7 +1014,6 @@ def build_config_from_args(
     args: argparse.Namespace,
     allow: AllowedFeatures,
     nix_path: str,
-    nixpkgs_config: Path,
 ) -> BuildConfig:
     """Create a BuildConfig from parsed CLI arguments."""
     workers, max_memory_size = default_eval_resources(
@@ -1019,7 +1022,6 @@ def build_config_from_args(
     return BuildConfig(
         allow=allow,
         nix_path=nix_path,
-        nixpkgs_config=nixpkgs_config,
         num_eval_workers=workers,
         max_memory_size=max_memory_size,
         pkgs=args.pkgs,
@@ -1043,6 +1045,7 @@ def _review_from_args(
         review_config=ReviewConfig(
             remote=args.remote,
             extra_nixpkgs_config=args.extra_nixpkgs_config,
+            extra_nixpkgs_args=args.extra_nixpkgs_args,
             systems=args.systems.split(" "),
             eval_type="local",
         ),
@@ -1066,23 +1069,22 @@ class LocalRevisionTarget:
 
 
 def review_local_revision(
-    builddir_path: str,
+    builddir: Builddir,
     args: argparse.Namespace,
     build_config_factory: Callable[[str], BuildConfig],
     target: LocalRevisionTarget | None = None,
 ) -> Path:
     target = target or LocalRevisionTarget()
-    with Builddir(builddir_path) as builddir:
-        review = _review_from_args(
-            builddir,
-            args,
-            build_config_factory(builddir.nix_path),
-        )
-        review.review_commit(
-            builddir.path,
-            args.branch,
-            target.commit,
-            action=target.action,
-            staged=target.staged,
-        )
-        return builddir.path
+    review = _review_from_args(
+        builddir,
+        args,
+        build_config_factory(builddir.nix_path),
+    )
+    review.review_commit(
+        builddir.path,
+        args.branch,
+        target.commit,
+        action=target.action,
+        staged=target.staged,
+    )
+    return builddir.path

--- a/tests/assets/nixpkgs/default.nix
+++ b/tests/assets/nixpkgs/default.nix
@@ -1,11 +1,5 @@
 {
-  config ? (
-    let configFile = builtins.getEnv "NIXPKGS_CONFIG";
-    in
-      if configFile != "" && builtins.pathExists configFile then
-        import configFile
-      else
-        { }),
+  config, # no default, to ensure it's being passed to real nixpkgs
   system ? null, # deadnix: skip
 }@args:
 with import ./config.nix;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,7 +130,9 @@ def setup_nixpkgs(target: Path) -> Path:
         # Use paths without quotes so Nix treats them as paths and copies them to the store
         content = content.replace("@bash@", f"{bash_source}/bin/bash")
         content = content.replace("@coreutils@", f"{coreutils_source}/bin")
-        content = content.replace("@lib@", f"(import {nixpkgs_path} {{}}).lib")
+        content = content.replace(
+            "@lib@", f"(import {nixpkgs_path} {{ config = {{}}; }}).lib"
+        )
         config_out.write_text(content)
 
     return target

--- a/tests/test_option_flag.py
+++ b/tests/test_option_flag.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import subprocess
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from nixpkgs_review.allow import AllowedFeatures
@@ -47,7 +46,6 @@ def _build_config(options: tuple[tuple[str, str], ...] = ()) -> BuildConfig:
     return BuildConfig(
         allow=AllowedFeatures([]),
         nix_path="",
-        nixpkgs_config=Path("/dev/null"),
         options=options,
     )
 
@@ -76,7 +74,7 @@ def test_build_config_from_args_carries_options() -> None:
         ["rev", "HEAD", "--option", "cores", "4", "--option", "max-jobs", "2"],
     )
     build_config: BuildConfig = build_config_from_args(
-        args, AllowedFeatures([]), nix_path="", nixpkgs_config=Path("/dev/null")
+        args, AllowedFeatures([]), nix_path=""
     )
     assert build_config.options == (("cores", "4"), ("max-jobs", "2"))
 

--- a/tests/test_rev.py
+++ b/tests/test_rev.py
@@ -155,7 +155,10 @@ def test_rev_command_with_pkgs_and_package(helpers: Helpers) -> None:
 
 
 @pytest.mark.parametrize("pkg_count", [0, 1, 10, 51])
-def test_rev_command_with_pkg_count(helpers: Helpers, pkg_count: int) -> None:
+@pytest.mark.parametrize("use_args", [False, True])
+def test_rev_command_with_pkg_count(
+    helpers: Helpers, *, pkg_count: int, use_args: bool
+) -> None:
     with helpers.nixpkgs() as nixpkgs:
         nixpkgs.path.joinpath("pkg1.txt").write_text("foo")
         subprocess.run(["git", "add", "."], check=True)
@@ -171,9 +174,18 @@ def test_rev_command_with_pkg_count(helpers: Helpers, pkg_count: int) -> None:
                 "exit 0",
                 "--build-graph",
                 "nix",
-                "--extra-nixpkgs-config",
-                f"{{ pkgCount = {pkg_count}; }}",
-            ],
+            ]
+            + (
+                [
+                    "--extra-nixpkgs-args",
+                    f"{{ config = {{ pkgCount = {pkg_count}; }}; }}",
+                ]
+                if use_args
+                else [
+                    "--extra-nixpkgs-config",
+                    f"{{ pkgCount = {pkg_count}; }}",
+                ]
+            ),
         )
         pkgs = {f"pkg{x + 1}" for x in range(pkg_count)}
         helpers.assert_built(path, *pkgs)

--- a/tests/test_store_flag.py
+++ b/tests/test_store_flag.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 from nixpkgs_review.allow import AllowedFeatures
 from nixpkgs_review.cli import parse_args
 from nixpkgs_review.nix import nix_common_flags
@@ -13,9 +11,7 @@ def test_store_flags_reach_nix_common_flags() -> None:
         "nixpkgs-review",
         ["rev", "HEAD", "--store", "local?root=/tmp/x", "--eval-store", "auto"],
     )
-    build_config = build_config_from_args(
-        args, AllowedFeatures([]), nix_path="", nixpkgs_config=Path("/dev/null")
-    )
+    build_config = build_config_from_args(args, AllowedFeatures([]), nix_path="")
     assert nix_common_flags(build_config)[-4:] == [
         "--store",
         "local?root=/tmp/x",


### PR DESCRIPTION
This is my attempt at making nixpkgs args customisable.  I mostly want this for testing PRs that fix cross-compilation of packages (using `crossSystem`).

- `Builddir` now requires a `Buildenv` so it can init `NIX_PATH` in one place
- `<nixpkgs>` is now a wrapper, which works in the shell, but may be confusing/breaking for people assuming that nixpkgs/ is the same thing
- We should be able to replace most of the `extra-nixpkgs-config` handling by combining it with args (unless we just want to remove it)
- It still needs more testing

Feedback would be appreciated.

Fixes: #375