### PR TITLE
pr: add Merge Bot merge if approved and build successful

### DIFF
--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -210,6 +210,11 @@ def common_flags() -> list[CommonFlag]:
             help="Approve PR on review success",
         ),
         CommonFlag(
+            "--merge-pr",
+            action="store_true",
+            help="Merge PR with Merge Bot on review success (must be used with --approve-pr)",
+        ),
+        CommonFlag(
             "-p",
             "--package",
             action="append",

--- a/nixpkgs_review/cli/pr.py
+++ b/nixpkgs_review/cli/pr.py
@@ -72,7 +72,11 @@ def pr_command(args: argparse.Namespace) -> str:
 
     pr_objects = _validate_pr_json(args, prs)
 
-    if args.post_result or args.approve_pr:
+    if args.merge_pr and not args.approve_pr:
+        warn("--merge-pr must be used with --approve-pr")
+        sys.exit(1)
+
+    if args.post_result or args.approve_pr or args.merge_pr:
         ensure_github_token(args.token)
 
     contexts: list[
@@ -141,6 +145,7 @@ def pr_command(args: argparse.Namespace) -> str:
                 post_result=args.post_result,
                 print_result=args.print_result,
                 approve_pr=args.approve_pr,
+                merge_pr=args.merge_pr,
             )
             for pr, path, attrs, commit in contexts
         )

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -546,6 +546,7 @@ class Review:
         post_result: bool | None = False,
         print_result: bool = False,
         approve_pr: bool = False,
+        merge_pr: bool = False,
     ) -> bool:
         os.environ.pop("NIXPKGS_CONFIG", None)
         os.environ["NIXPKGS_REVIEW_ROOT"] = str(path)
@@ -578,7 +579,8 @@ class Review:
         if pr and approve_pr and success:
             self.github_client.approve_pr(
                 pr,
-                "Approved automatically following the successful run of `nixpkgs-review`.",
+                "Approved automatically following the successful run of `nixpkgs-review`."
+                + ("\n\n@NixOS/nixpkgs-merge-bot merge" if merge_pr else ""),
             )
 
         if print_result:
@@ -608,6 +610,7 @@ class Review:
         staged: bool = False,
         print_result: bool = False,
         approve_pr: bool = False,
+        merge_pr: bool = False,
     ) -> None:
         branch_rev = fetch_refs(self.remote, branch)[0]
         self.start_review(
@@ -616,6 +619,7 @@ class Review:
             path,
             print_result=print_result,
             approve_pr=approve_pr,
+            merge_pr=merge_pr,
         )
 
 


### PR DESCRIPTION
Named merge-pr to avoid confusion with merge strategies.

Added as an extension to the approve dialog to reduce thread clutter/number of comments.

Requires the PR to be approved by the merger as well for an extra safety feature.

I think this feature could be especially helpful when reviewing/merging r-ryantm PRs...