### PR TITLE
ci: add weekly flake input update workflow

### DIFF
--- a/.github/workflows/update-flake-inputs.yml
+++ b/.github/workflows/update-flake-inputs.yml
@@ -1,0 +1,20 @@
+name: Update Flake Inputs
+on:
+  schedule:
+    - cron: "0 2 * * 1" # Every Monday at 02:00 UTC
+  workflow_dispatch:
+jobs:
+  update-flake-inputs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Setup Nix
+        uses: NixOS/nix-installer@main
+      - name: Update flake inputs
+        uses: mic92/update-flake-inputs@main
+        with:
+          auto-merge: true

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
-}


### PR DESCRIPTION
Keep flake inputs (nixpkgs, flake-parts, treefmt-nix) up-to-date automatically. Runs every Monday at 02:00 UTC, creating auto-merged PRs via the update-flake-inputs action.

Based on the same pattern used in dotfiles, but with a weekly cadence since this repo doesn't need daily updates.