### PR TITLE
Support bare nixpkgs repositories

### DIFF
--- a/nixpkgs_review/buildenv.py
+++ b/nixpkgs_review/buildenv.py
@@ -6,20 +6,11 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING
 
+from .nixpkgs import find_nixpkgs_root
 from .utils import die
 
 if TYPE_CHECKING:
     import types
-
-
-def find_nixpkgs_root() -> Path | None:
-    root_path = Path.cwd()
-    while True:
-        if (root_path / "nixos" / "release.nix").exists():
-            return root_path
-        if root_path == root_path.parent:
-            return None
-        root_path = root_path.parent
 
 
 class Buildenv:

--- a/nixpkgs_review/cli/wip.py
+++ b/nixpkgs_review/cli/wip.py
@@ -6,12 +6,14 @@ from typing import TYPE_CHECKING
 from nixpkgs_review import git
 from nixpkgs_review.allow import AllowedFeatures
 from nixpkgs_review.buildenv import Buildenv
+from nixpkgs_review.nixpkgs import is_bare_repository
 from nixpkgs_review.review import (
     LocalRevisionTarget,
     ReviewAction,
     build_config_from_args,
     review_local_revision,
 )
+from nixpkgs_review.utils import die
 
 if TYPE_CHECKING:
     import argparse
@@ -23,6 +25,11 @@ def wip_command(args: argparse.Namespace) -> Path:
     with Buildenv(
         allow_aliases=allow.aliases, extra_nixpkgs_config=args.extra_nixpkgs_config
     ) as nixpkgs_config:
+        if is_bare_repository():
+            die(
+                "The `wip` command requires a working tree, but the current repository "
+                "is bare. Use `nixpkgs-review pr` or `nixpkgs-review rev <commit>` instead."
+            )
         return review_local_revision(
             f"rev-{git.verify_commit_hash('HEAD')}-dirty",
             args,

--- a/nixpkgs_review/nixpkgs.py
+++ b/nixpkgs_review/nixpkgs.py
@@ -1,0 +1,132 @@
+"""Utilities for locating and identifying a nixpkgs git repository."""
+
+from __future__ import annotations
+
+import fcntl
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+from typing import IO, TYPE_CHECKING
+
+from .errors import NixpkgsReviewError
+from .utils import sh
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+def is_bare_repository() -> bool:
+    """Check if CWD is inside a bare git repository."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--is-bare-repository"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def _is_bare_nixpkgs_repo() -> Path | None:
+    """Check if CWD is a bare git repo containing nixpkgs.
+
+    Returns the repo root path if so, None otherwise.
+    """
+    if not is_bare_repository():
+        return None
+
+    has_nixpkgs = subprocess.run(
+        ["git", "cat-file", "-e", "HEAD:nixos/release.nix"],
+        capture_output=True,
+        check=False,
+    )
+    if has_nixpkgs.returncode != 0:
+        return None
+
+    return Path.cwd()
+
+
+def find_nixpkgs_root() -> Path | None:
+    """Find the root of a nixpkgs repository from CWD.
+
+    Walks up from CWD looking for nixos/release.nix on disk.  If that fails,
+    checks whether CWD is a bare nixpkgs repo (where the file exists only in
+    the git tree, not on the filesystem).
+    """
+    root_path = Path.cwd()
+    while True:
+        if (root_path / "nixos" / "release.nix").exists():
+            return root_path
+        if root_path == root_path.parent:
+            break
+        root_path = root_path.parent
+
+    return _is_bare_nixpkgs_repo()
+
+
+def resolve_git_dir() -> Path:
+    """Return the path to the git directory for the repo at CWD."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--git-dir"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        msg = "Cannot find git directory in current directory"
+        raise NixpkgsReviewError(msg)
+    return Path(result.stdout.strip())
+
+
+@contextmanager
+def locked_open(filename: Path, mode: str = "r") -> Iterator[IO[str]]:
+    """
+    This is a context manager that provides an advisory write lock on the file specified by `filename` when entering the context, and releases the lock when leaving the context.
+    The lock is acquired using the `fcntl` module's `LOCK_EX` flag, which applies an exclusive write lock to the file.
+    """
+    with filename.open(mode) as fd:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield fd
+        fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+def fetch_refs(repo: str, *refs: str, shallow_depth: int = 1) -> list[str]:
+    shallow = subprocess.run(
+        ["git", "rev-parse", "--is-shallow-repository"],
+        text=True,
+        stdout=subprocess.PIPE,
+        check=False,
+    )
+    if shallow.returncode != 0:
+        msg = f"Failed to detect if {repo} is shallow repository"
+        raise NixpkgsReviewError(msg)
+
+    fetch_cmd = [
+        "git",
+        "-c",
+        "fetch.prune=false",
+        "fetch",
+        "--no-tags",
+        "--force",
+        repo,
+    ]
+    if shallow.stdout.strip() == "true":
+        fetch_cmd.append(f"--depth={shallow_depth}")
+    for i, ref in enumerate(refs):
+        fetch_cmd.append(f"{ref}:refs/nixpkgs-review/{i}")
+    dotgit = resolve_git_dir()
+    with locked_open(dotgit / "nixpkgs-review", "w"):
+        res = sh(fetch_cmd)
+        if res.returncode != 0:
+            msg = f"Failed to fetch {refs} from {repo}. git fetch failed with exit code {res.returncode}"
+            raise NixpkgsReviewError(msg)
+        shas = []
+        for i, ref in enumerate(refs):
+            rev_parse_cmd = ["git", "rev-parse", "--verify", f"refs/nixpkgs-review/{i}"]
+            out = subprocess.run(
+                rev_parse_cmd, text=True, stdout=subprocess.PIPE, check=False
+            )
+            if out.returncode != 0:
+                msg = f"Failed to fetch {ref} from {repo} with command: {''.join(rev_parse_cmd)}"
+                raise NixpkgsReviewError(msg)
+            shas.append(out.stdout.strip())
+        return shas

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import fcntl
 import itertools
 import os
 import shutil
@@ -8,7 +7,6 @@ import subprocess
 import sys
 import tempfile
 import time
-from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -19,6 +17,7 @@ from xml.etree import ElementTree as ET
 from . import git, http_requests
 from .builddir import Builddir
 from .errors import NixpkgsReviewError
+from .nixpkgs import fetch_refs, resolve_git_dir
 from .github import GithubClient, GitHubPullRequest
 from .nix import Attr, BuildConfig, ShellConfig, multi_system_eval, nix_build, nix_shell
 from .report import Report, ReportOptions
@@ -28,7 +27,6 @@ from .utils import (
     current_system,
     die,
     info,
-    sh,
     system_order_key,
     warn,
 )
@@ -957,76 +955,6 @@ def filter_packages_per_system(
 
     return result
 
-
-@contextmanager
-def locked_open(filename: Path, mode: str = "r") -> Iterator[IO[str]]:
-    """
-    This is a context manager that provides an advisory write lock on the file specified by `filename` when entering the context, and releases the lock when leaving the context.
-    The lock is acquired using the `fcntl` module's `LOCK_EX` flag, which applies an exclusive write lock to the file.
-    """
-    with filename.open(mode) as fd:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-        yield fd
-        fcntl.flock(fd, fcntl.LOCK_UN)
-
-
-def resolve_git_dir() -> Path:
-    dotgit = Path(".git")
-    match (dotgit.is_file(), dotgit.is_dir()):
-        case (True, False):
-            actual_git_dir = dotgit.read_text().strip()
-            if not actual_git_dir.startswith("gitdir: "):
-                msg = f"Invalid .git file: {actual_git_dir} found in current directory"
-                raise NixpkgsReviewError(msg)
-            return Path() / actual_git_dir[8:]
-        case (False, True):
-            return dotgit
-        case _:
-            msg = "Cannot find .git file or directory in current directory"
-            raise NixpkgsReviewError(msg)
-
-
-def fetch_refs(repo: str, *refs: str, shallow_depth: int = 1) -> list[str]:
-    shallow = subprocess.run(
-        ["git", "rev-parse", "--is-shallow-repository"],
-        text=True,
-        stdout=subprocess.PIPE,
-        check=False,
-    )
-    if shallow.returncode != 0:
-        msg = f"Failed to detect if {repo} is shallow repository"
-        raise NixpkgsReviewError(msg)
-
-    fetch_cmd = [
-        "git",
-        "-c",
-        "fetch.prune=false",
-        "fetch",
-        "--no-tags",
-        "--force",
-        repo,
-    ]
-    if shallow.stdout.strip() == "true":
-        fetch_cmd.append(f"--depth={shallow_depth}")
-    for i, ref in enumerate(refs):
-        fetch_cmd.append(f"{ref}:refs/nixpkgs-review/{i}")
-    dotgit = resolve_git_dir()
-    with locked_open(dotgit / "nixpkgs-review", "w"):
-        res = sh(fetch_cmd)
-        if res.returncode != 0:
-            msg = f"Failed to fetch {refs} from {repo}. git fetch failed with exit code {res.returncode}"
-            raise NixpkgsReviewError(msg)
-        shas = []
-        for i, ref in enumerate(refs):
-            rev_parse_cmd = ["git", "rev-parse", "--verify", f"refs/nixpkgs-review/{i}"]
-            out = subprocess.run(
-                rev_parse_cmd, text=True, stdout=subprocess.PIPE, check=False
-            )
-            if out.returncode != 0:
-                msg = f"Failed to fetch {ref} from {repo} with command: {''.join(rev_parse_cmd)}"
-                raise NixpkgsReviewError(msg)
-            shas.append(out.stdout.strip())
-        return shas
 
 
 def differences(

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -17,9 +17,9 @@ from xml.etree import ElementTree as ET
 from . import git, http_requests
 from .builddir import Builddir
 from .errors import NixpkgsReviewError
-from .nixpkgs import fetch_refs, resolve_git_dir
 from .github import GithubClient, GitHubPullRequest
 from .nix import Attr, BuildConfig, ShellConfig, multi_system_eval, nix_build, nix_shell
+from .nixpkgs import fetch_refs
 from .report import Report, ReportOptions
 from .utils import (
     PackageFilter,
@@ -33,7 +33,7 @@ from .utils import (
 
 if TYPE_CHECKING:
     import argparse
-    from collections.abc import Callable, Iterator
+    from collections.abc import Callable
     from re import Pattern
 
     from .allow import AllowedFeatures
@@ -954,7 +954,6 @@ def filter_packages_per_system(
         )
 
     return result
-
 
 
 def differences(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,6 +248,31 @@ sandbox-build-dir = {test_nix_dir.joinpath("build")}
                 yield setup_git(nixpkgs_path)
 
 
+@pytest.fixture(autouse=True, scope="session")
+def _isolate_git() -> Iterator[None]:
+    """Prevent the user's git configuration from affecting tests.
+
+    Sets identity variables and points GIT_CONFIG_GLOBAL / GIT_CONFIG_SYSTEM
+    at /dev/null so settings like commit.gpgsign or gpg.format don't leak in.
+    """
+    overrides = {
+        "GIT_AUTHOR_NAME": "nixpkgs-review",
+        "GIT_AUTHOR_EMAIL": "nixpkgs-review@example.com",
+        "GIT_COMMITTER_NAME": "nixpkgs-review",
+        "GIT_COMMITTER_EMAIL": "nixpkgs-review@example.com",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+    }
+    saved = {k: os.environ.get(k) for k in overrides}
+    os.environ.update(overrides)
+    yield
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
 @pytest.fixture
 def helpers() -> type[Helpers]:
     return Helpers

--- a/tests/test_nixpkgs.py
+++ b/tests/test_nixpkgs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -15,19 +16,11 @@ from nixpkgs_review.nixpkgs import find_nixpkgs_root
 from .conftest import Chdir, Helpers
 
 
-GIT_ENV = {
-    "GIT_AUTHOR_NAME": "test",
-    "GIT_AUTHOR_EMAIL": "test@test",
-    "GIT_COMMITTER_NAME": "test",
-    "GIT_COMMITTER_EMAIL": "test@test",
-}
+def git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True)
 
 
-def _git(repo: Path, *args: str) -> None:
-    subprocess.run(["git", "-C", str(repo), *args], check=True, env={**os.environ, **GIT_ENV})
-
-
-def _make_bare_with_dotgit(path: Path) -> Path:
+def make_bare_with_dotgit(path: Path) -> Path:
     """Create a bare repo that has a .git/ directory and nixos/release.nix in its tree.
 
     This mimics the layout:
@@ -46,17 +39,15 @@ def _make_bare_with_dotgit(path: Path) -> Path:
     (repo / "nixos").mkdir()
     (repo / "nixos" / "release.nix").write_text("{}")
 
-    _git(repo, "init", "-b", "master")
-    _git(repo, "add", ".")
-    _git(repo, "commit", "-m", "init")
+    git(repo, "init", "-b", "master")
+    git(repo, "add", ".")
+    git(repo, "commit", "-m", "init")
 
     # Set core.bare = true and remove working tree files
-    _git(repo, "config", "core.bare", "true")
+    git(repo, "config", "core.bare", "true")
     for child in repo.iterdir():
         if child.name != ".git":
             if child.is_dir():
-                import shutil
-
                 shutil.rmtree(child)
             else:
                 child.unlink()
@@ -64,19 +55,7 @@ def _make_bare_with_dotgit(path: Path) -> Path:
     return repo
 
 
-def test_find_nixpkgs_root_in_bare_repo_with_dotgit(helpers: Helpers) -> None:
-    """find_nixpkgs_root() should detect a bare nixpkgs repo that has a .git/ directory."""
-    with helpers.save_environ(), tempfile.TemporaryDirectory() as tmpdir:
-        path = Path(tmpdir).resolve()
-        bare_root = _make_bare_with_dotgit(path)
-
-        with Chdir(bare_root):
-            result = find_nixpkgs_root()
-            assert result is not None
-            assert result == bare_root
-
-
-def _make_true_bare(path: Path, *, with_nixpkgs: bool = True) -> Path:
+def make_true_bare(path: Path, *, with_nixpkgs: bool = True) -> Path:
     """Create a true bare repo (git clone --bare style): no .git directory at all.
 
     The git database (HEAD, objects, refs, ...) lives directly in the returned directory.
@@ -90,15 +69,14 @@ def _make_true_bare(path: Path, *, with_nixpkgs: bool = True) -> Path:
     else:
         (src / "README.md").write_text("not nixpkgs")
 
-    _git(src, "init", "-b", "master")
-    _git(src, "add", ".")
-    _git(src, "commit", "-m", "init")
+    git(src, "init", "-b", "master")
+    git(src, "add", ".")
+    git(src, "commit", "-m", "init")
 
     bare = path / "bare.git"
     subprocess.run(
         ["git", "clone", "--bare", str(src), str(bare)],
         check=True,
-        env={**os.environ, **GIT_ENV},
     )
     return bare
 
@@ -107,7 +85,7 @@ def test_find_nixpkgs_root_in_true_bare_repo(helpers: Helpers) -> None:
     """find_nixpkgs_root() should detect a true bare nixpkgs repo (no .git directory)."""
     with helpers.save_environ(), tempfile.TemporaryDirectory() as tmpdir:
         path = Path(tmpdir).resolve()
-        bare_root = _make_true_bare(path, with_nixpkgs=True)
+        bare_root = make_true_bare(path, with_nixpkgs=True)
 
         with Chdir(bare_root):
             result = find_nixpkgs_root()
@@ -115,17 +93,14 @@ def test_find_nixpkgs_root_in_true_bare_repo(helpers: Helpers) -> None:
             assert result == bare_root
 
 
-
 def test_wip_command_fails_in_bare_repo(helpers: Helpers) -> None:
     """wip command should fail early with a clear message in a bare repo."""
     with helpers.save_environ(), tempfile.TemporaryDirectory() as tmpdir:
         path = Path(tmpdir).resolve()
-        bare_root = _make_bare_with_dotgit(path)
+        bare_root = make_bare_with_dotgit(path)
         os.environ["XDG_CACHE_HOME"] = str(path / "cache")
 
         with Chdir(bare_root), pytest.raises(SystemExit, match="1"):
-            from nixpkgs_review.cli import main
-
             main(
                 "nixpkgs-review",
                 ["wip", "--remote", str(bare_root), "--build-graph", "nix"],
@@ -142,10 +117,10 @@ def test_find_nixpkgs_root_returns_none_for_non_nixpkgs_bare_repo(
         repo.mkdir()
         (repo / "README.md").write_text("not nixpkgs")
 
-        _git(repo, "init", "-b", "master")
-        _git(repo, "add", ".")
-        _git(repo, "commit", "-m", "init")
-        _git(repo, "config", "core.bare", "true")
+        git(repo, "init", "-b", "master")
+        git(repo, "add", ".")
+        git(repo, "commit", "-m", "init")
+        git(repo, "config", "core.bare", "true")
 
         with Chdir(repo):
             result = find_nixpkgs_root()

--- a/tests/test_nixpkgs.py
+++ b/tests/test_nixpkgs.py
@@ -1,0 +1,152 @@
+"""Tests for nixpkgs repository detection (nixpkgs_review.nixpkgs)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from nixpkgs_review.cli import main
+from nixpkgs_review.nixpkgs import find_nixpkgs_root
+
+from .conftest import Chdir, Helpers
+
+
+GIT_ENV = {
+    "GIT_AUTHOR_NAME": "test",
+    "GIT_AUTHOR_EMAIL": "test@test",
+    "GIT_COMMITTER_NAME": "test",
+    "GIT_COMMITTER_EMAIL": "test@test",
+}
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, env={**os.environ, **GIT_ENV})
+
+
+def _make_bare_with_dotgit(path: Path) -> Path:
+    """Create a bare repo that has a .git/ directory and nixos/release.nix in its tree.
+
+    This mimics the layout:
+        path/
+        ├── .git/          ← real directory, core.bare = true
+        │   ├── HEAD
+        │   ├── objects/
+        │   └── ...
+        └── (no working tree files)
+
+    Returns the bare repo root.
+    """
+    # Create a normal repo with just nixos/release.nix
+    repo = path / "repo"
+    repo.mkdir()
+    (repo / "nixos").mkdir()
+    (repo / "nixos" / "release.nix").write_text("{}")
+
+    _git(repo, "init", "-b", "master")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "init")
+
+    # Set core.bare = true and remove working tree files
+    _git(repo, "config", "core.bare", "true")
+    for child in repo.iterdir():
+        if child.name != ".git":
+            if child.is_dir():
+                import shutil
+
+                shutil.rmtree(child)
+            else:
+                child.unlink()
+
+    return repo
+
+
+def test_find_nixpkgs_root_in_bare_repo_with_dotgit(helpers: Helpers) -> None:
+    """find_nixpkgs_root() should detect a bare nixpkgs repo that has a .git/ directory."""
+    with helpers.save_environ(), tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir).resolve()
+        bare_root = _make_bare_with_dotgit(path)
+
+        with Chdir(bare_root):
+            result = find_nixpkgs_root()
+            assert result is not None
+            assert result == bare_root
+
+
+def _make_true_bare(path: Path, *, with_nixpkgs: bool = True) -> Path:
+    """Create a true bare repo (git clone --bare style): no .git directory at all.
+
+    The git database (HEAD, objects, refs, ...) lives directly in the returned directory.
+    """
+    # Create a normal repo first, then clone --bare
+    src = path / "src"
+    src.mkdir()
+    if with_nixpkgs:
+        (src / "nixos").mkdir()
+        (src / "nixos" / "release.nix").write_text("{}")
+    else:
+        (src / "README.md").write_text("not nixpkgs")
+
+    _git(src, "init", "-b", "master")
+    _git(src, "add", ".")
+    _git(src, "commit", "-m", "init")
+
+    bare = path / "bare.git"
+    subprocess.run(
+        ["git", "clone", "--bare", str(src), str(bare)],
+        check=True,
+        env={**os.environ, **GIT_ENV},
+    )
+    return bare
+
+
+def test_find_nixpkgs_root_in_true_bare_repo(helpers: Helpers) -> None:
+    """find_nixpkgs_root() should detect a true bare nixpkgs repo (no .git directory)."""
+    with helpers.save_environ(), tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir).resolve()
+        bare_root = _make_true_bare(path, with_nixpkgs=True)
+
+        with Chdir(bare_root):
+            result = find_nixpkgs_root()
+            assert result is not None
+            assert result == bare_root
+
+
+
+def test_wip_command_fails_in_bare_repo(helpers: Helpers) -> None:
+    """wip command should fail early with a clear message in a bare repo."""
+    with helpers.save_environ(), tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir).resolve()
+        bare_root = _make_bare_with_dotgit(path)
+        os.environ["XDG_CACHE_HOME"] = str(path / "cache")
+
+        with Chdir(bare_root), pytest.raises(SystemExit, match="1"):
+            from nixpkgs_review.cli import main
+
+            main(
+                "nixpkgs-review",
+                ["wip", "--remote", str(bare_root), "--build-graph", "nix"],
+            )
+
+
+def test_find_nixpkgs_root_returns_none_for_non_nixpkgs_bare_repo(
+    helpers: Helpers,
+) -> None:
+    """find_nixpkgs_root() should return None for a bare repo that isn't nixpkgs."""
+    with helpers.save_environ(), tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir).resolve()
+        repo = path / "repo"
+        repo.mkdir()
+        (repo / "README.md").write_text("not nixpkgs")
+
+        _git(repo, "init", "-b", "master")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "init")
+        _git(repo, "config", "core.bare", "true")
+
+        with Chdir(repo):
+            result = find_nixpkgs_root()
+            assert result is None


### PR DESCRIPTION
# Supporting bare nixpkgs repositories

## The problem

I keep my nixpkgs checkout as a bare repo with worktrees:

```
~/nixpkgs/
├── .git/              (core.bare = true)
├── master/            (worktree)
├── staging/           (worktree)
├── pr-work/           (worktree)
└── ...
```

I learned this git workflow for large repos with many workstreams (like nixpkgs)! from @ericson2314. You clone once, set `core.bare = true`, and then `git worktree add` for each branch you're working on. No files are checked out at the root; the worktrees live as sibling
directories alongside `.git/`. It's pretty awesome.

Today, when I `cd ~/nixpkgs` and run `nixpkgs-review pr 12345`, it dies immediately with "Has to be executed from nixpkgs repository". The tool can't tell it's inside nixpkgs because there's no `nixos/release.nix` on disk at the root level -- it only exists inside the worktrees.

Running from inside a worktree (`cd ~/nixpkgs/master && nixpkgs-review pr ...`) works fine, but it's annoying to have to pick an arbitrary worktree just to launch a review that creates its own worktree anyway.

## What was broken

Two functions assumed a working tree exists:

1. **`find_nixpkgs_root()`** walks up from CWD looking for `nixos/release.nix` on the filesystem. In a bare repo there are no checked-out files, so it walks all the way to `/` and gives up.

2. **`resolve_git_dir()`** looks for a `.git` file or directory.  My layout has `.git/` as a directory so this one actually works for me, but a "true" bare clone (`git clone --bare`) has no `.git` entry at all -- the git database (HEAD, objects, refs) lives directly in the directory. That case would also fail.

## What this PR does

**`find_nixpkgs_root()`** now falls back to git when the filesystem walk fails. It asks `git rev-parse --is-bare-repository` whether we're in a bare repo, then checks `git cat-file -e HEAD:nixos/release.nix` to confirm the repo actually contains nixpkgs (not just any bare repo). If both pass, it returns CWD as the root.

**`resolve_git_dir()`** gets a similar fallback: when there's no `.git` on disk, it tries `git rev-parse --git-dir`, which works in true bare clones where the git database is the directory itself.

**`wip` is guarded** with an early exit in bare repos. The `wip` command captures the dirty working tree via `git diff`, but a bare repo has no working tree to diff.  Rather than letting it silently produce an empty diff and exit, it now tells you to use `pr` or `rev` instead.

The non-bare case is unchanged -- the filesystem walk still runs first, so there's no subprocess overhead for the common case.

## Refactoring

Along the way, `find_nixpkgs_root`, `resolve_git_dir`, `fetch_refs`, and friends were extracted from `buildenv.py` and `review.py` into a new `nixpkgs.py` module, since they're all about locating and interacting with the nixpkgs git repo rather than about the build environment or the review workflow.

The test suite also got a session-scoped fixture that sets `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` to `/dev/null`, so the user's git config (things like `commit.gpgsign = true`) can't break test commits. Previously -- at least on my system -- this required passing those env vars on the command line every time I ran `pytest`.

## AI-assisted

As you likely can tell, my friend Claude helped with this implementation. I've reviewed it and think it's pretty slop-free, but please let me know your own tastes on the matter.