### PR TITLE
Fix sandboxed `--build-graph nom` when nom is installed in ~

### DIFF
--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -127,19 +127,22 @@ def nix_shell(
         nixpkgs_config=config.nixpkgs_config,
         pkgs=config.pkgs,
     )
-    with TemporaryDirectory(prefix="nixpkgs-review-links-") as dirname:
-        bin_link = Path(dirname) / bin_name
-        bin_link.symlink_to(os.path.realpath(nix_shell_bin))
-        if config.sandbox:
+    if config.sandbox:
+        with TemporaryDirectory(prefix="nixpkgs-review-links-") as dirname:
+            bin_link = Path(dirname) / bin_name
+            bin_link.symlink_to(os.path.realpath(nix_shell_bin))
             args = _nix_shell_sandbox(str(bin_link), shell_file_args, config, dirname)
-        else:
-            args = [
-                str(bin_link),
-                *shell_file_args,
-                "--nix-path",
-                config.nix_path,
-                REVIEW_SHELL,
-            ]
+            if config.run:
+                args.extend(["--run", config.run])
+            sh(args, cwd=config.cache_directory)
+    else:
+        args = [
+            nix_shell_bin,
+            *shell_file_args,
+            "--nix-path",
+            config.nix_path,
+            REVIEW_SHELL,
+        ]
         if config.run:
             args.extend(["--run", config.run])
         sh(args, cwd=config.cache_directory)

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -8,7 +8,7 @@ import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 from sys import platform
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import TYPE_CHECKING, Final, NotRequired, TypedDict
 
 from .errors import NixpkgsReviewError
@@ -127,25 +127,29 @@ def nix_shell(
         nixpkgs_config=config.nixpkgs_config,
         pkgs=config.pkgs,
     )
-    if config.sandbox:
-        args = _nix_shell_sandbox(nix_shell_bin, shell_file_args, config)
-    else:
-        args = [
-            nix_shell_bin,
-            *shell_file_args,
-            "--nix-path",
-            config.nix_path,
-            REVIEW_SHELL,
-        ]
-    if config.run:
-        args.extend(["--run", config.run])
-    sh(args, cwd=config.cache_directory)
+    with TemporaryDirectory(prefix="nixpkgs-review-links-") as dirname:
+        bin_link = Path(dirname) / bin_name
+        bin_link.symlink_to(os.path.realpath(nix_shell_bin))
+        if config.sandbox:
+            args = _nix_shell_sandbox(str(bin_link), shell_file_args, config, dirname)
+        else:
+            args = [
+                str(bin_link),
+                *shell_file_args,
+                "--nix-path",
+                config.nix_path,
+                REVIEW_SHELL,
+            ]
+        if config.run:
+            args.extend(["--run", config.run])
+        sh(args, cwd=config.cache_directory)
 
 
 def _nix_shell_sandbox(
     nix_shell: str,
     shell_file_args: list[str],
     config: ShellConfig,
+    extra_bind_dir: str,
 ) -> list[str]:
     if platform != "linux":
         msg = "Sandbox mode is only available on Linux platforms."
@@ -219,6 +223,7 @@ def _nix_shell_sandbox(
         # GitHub
         *bind(hub_config, try_=True),
         *bind(gh_config, try_=True),
+        *bind(extra_bind_dir),
     ]
     return [
         bwrap,


### PR DESCRIPTION
I have nom installed with home-manager. When using `--sandbox`, I was getting the following error:

```
bwrap: execvp /home/ash/.nix-profile/bin/nom-shell: No such file or directory
```

I presume this is because my home directory is getting obscured by a tmpfs before nom-shell could be executed.

To fix this, we create a temporary directory with an appropriately-named symlink to `nom`, and use that instead of the `nom` from $PATH. (Just pre-resolving the symlink at `/home/ash/.nix-profile/bin/nom-shell` doesn't work, because that produces the path to the `nom` binary, which behaves differently depending on the name it's invoked as – removing one layer of symlinks would work on my machine, but would be fragile and probably break other users.)