### PR TITLE
update instructions to use without installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ automatically builds packages changed in the pull requests.
 To use it without installing it, use:
 
 ```console
-$ nix run 'nixpkgs#nixpkgs-review'
+$ nix run 'nixpkgs#nixpkgs-review' -- pr <PR number>
 ```
 
 To run it from the git repository:


### PR DESCRIPTION
The example shows how to add flags to the command without installing it.

I added `--post-result` as i think that it is mostly used for this purpose.