### PR TITLE
fix: avoid no-url-literals warning

### DIFF
--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -86,7 +86,8 @@ REVIEW_SHELL: Final[str] = str(ROOT.joinpath("nix/review-shell.nix"))
 def _nix_common_flags(allow: AllowedFeatures, nix_path: str) -> list[str]:
     return [
         "--extra-experimental-features",
-        "nix-command" if allow.url_literals else "nix-command no-url-literals",
+        "nix-command",
+        *([] if allow.url_literals else ["--option", "lint-url-literals", "fatal"]),
         "--nix-path",
         nix_path,
         "--allow-import-from-derivation"

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -753,8 +753,7 @@ def _list_packages_system(
 ) -> list[Package]:
     cmd = [
         "nix-env",
-        "--extra-experimental-features",
-        "" if allow.url_literals else "no-url-literals",
+        *([] if allow.url_literals else ["--option", "lint-url-literals", "fatal"]),
         "--option",
         "system",
         system,


### PR DESCRIPTION
Nix 2.34+ warns:

```
experimental feature 'no-url-literals' has been stabilized and
renamed; use 'lint-url-literals = fatal' setting instead
```

Use lint-url-literals instead of the deprecated no-url-literals experimental feature. Older Nix releases ignore the option, so URL literals remain allowed there.
