### PR TITLE
Use per-platform attrdiff data from GitHub Actions

### DIFF
--- a/nixpkgs_review/github.py
+++ b/nixpkgs_review/github.py
@@ -64,6 +64,7 @@ class GitHubArtifactsResponse(TypedDict):
 
 
 class GitHubChangedPaths(TypedDict, total=False):
+    attrdiffByPlatform: dict[str, JSONType]
     rebuildsByPlatform: dict[str, list[str]]
 
 
@@ -295,16 +296,45 @@ class GithubClient:
             msg = f"Expected changed_paths to be a dict, got {type(changed_paths)}"
             raise TypeError(msg)
 
+        packages_per_system: dict[System, set[str]] = {}
         if (path := changed_paths.get("rebuildsByPlatform")) is not None:
             if not isinstance(path, dict):
                 msg = f"Expected rebuildsByPlatform to be a dict, got {type(path)}"
                 raise TypeError(msg)
-            return {
-                # Convert package lists to package sets
-                system: set(packages_list)
-                for system, packages_list in path.items()
-            }
-        return None
+            for system, packages_list in path.items():
+                if not isinstance(packages_list, list):
+                    msg = f"Expected rebuildsByPlatform.{system} to be a list, got {type(packages_list)}"
+                    raise TypeError(msg)
+                packages_per_system[cast("System", system)] = set(packages_list)
+
+        if (attrdiff_by_platform := changed_paths.get("attrdiffByPlatform")) is not None:
+            if not isinstance(attrdiff_by_platform, dict):
+                msg = f"Expected attrdiffByPlatform to be a dict, got {type(attrdiff_by_platform)}"
+                raise TypeError(msg)
+
+            # Newer CI artifacts expose per-platform additions/removals directly.
+            # Reuse the CI-selected rebuild set and add only the pieces that would
+            # otherwise be lost in reporting: new attrs and removed attrs.
+            for system, platform_diff in attrdiff_by_platform.items():
+                if not isinstance(platform_diff, dict):
+                    msg = (
+                        f"Expected attrdiffByPlatform.{system} to be a dict, "
+                        f"got {type(platform_diff)}"
+                    )
+                    raise TypeError(msg)
+                packages = packages_per_system.setdefault(cast("System", system), set())
+                for kind in ("added", "removed"):
+                    if (package_names := platform_diff.get(kind)) is None:
+                        continue
+                    if not isinstance(package_names, list):
+                        msg = (
+                            f"Expected attrdiffByPlatform.{system}.{kind} to be a list, "
+                            f"got {type(package_names)}"
+                        )
+                        raise TypeError(msg)
+                    packages.update(package_names)
+
+        return packages_per_system or None
 
     def get_github_action_eval_result(
         self, pr: GitHubPullRequest

--- a/nixpkgs_review/github.py
+++ b/nixpkgs_review/github.py
@@ -65,7 +65,8 @@ class GitHubArtifactsResponse(TypedDict):
 
 
 class GitHubChangedPaths(TypedDict, total=False):
-    rebuildsByPlatform: dict[str, list[str]]
+    attrdiffByPlatform: dict[System, dict[str, list[str]]]
+    rebuildsByPlatform: dict[System, list[str]]
 
 
 def pr_url(pr: int) -> str:
@@ -288,24 +289,24 @@ class GithubClient:
     def _process_comparison_artifact(
         self, artifact_id: int
     ) -> dict[System, set[str]] | None:
-        changed_paths = self.get_json_from_artifact(
+        raw = self.get_json_from_artifact(
             workflow_id=artifact_id,
             json_filename="changed-paths.json",
         )
-        if not isinstance(changed_paths, dict):
-            msg = f"Expected changed_paths to be a dict, got {type(changed_paths)}"
+        if not isinstance(raw, dict):
+            msg = f"Expected changed_paths to be a dict, got {type(raw)}"
             raise TypeError(msg)
+        changed_paths = cast("GitHubChangedPaths", raw)
 
-        if (path := changed_paths.get("rebuildsByPlatform")) is not None:
-            if not isinstance(path, dict):
-                msg = f"Expected rebuildsByPlatform to be a dict, got {type(path)}"
-                raise TypeError(msg)
-            return {
-                # Convert package lists to package sets
-                system: set(packages_list)
-                for system, packages_list in path.items()
-            }
-        return None
+        packages_per_system: dict[System, set[str]] = {}
+        for system, rebuilds in (changed_paths.get("rebuildsByPlatform") or {}).items():
+            packages_per_system.setdefault(system, set()).update(rebuilds)
+        # rebuildsByPlatform omits added/removed attrs; without them a pure
+        # package removal is reported as "no rebuilds".
+        for system, diff in (changed_paths.get("attrdiffByPlatform") or {}).items():
+            packages = packages_per_system.setdefault(system, set())
+            packages.update(diff.get("added", []), diff.get("removed", []))
+        return packages_per_system or None
 
     def get_github_action_eval_result(
         self, pr: GitHubPullRequest

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -269,19 +269,18 @@ class SystemReport:
         self.built: list[Attr] = []
 
         for attr in attrs:
-            match attr:
-                case _ if attr.broken:
-                    self.broken.append(attr)
-                case _ if attr.blacklisted:
-                    self.blacklisted.append(attr)
-                case _ if not attr.exists:
-                    self.non_existent.append(attr)
-                case _ if not attr.was_build():
-                    self.failed.append(attr)
-                case _ if attr.is_test():
-                    self.tests.append(attr)
-                case _:
-                    self.built.append(attr)
+            if not attr.exists:
+                self.non_existent.append(attr)
+            elif attr.broken:
+                self.broken.append(attr)
+            elif attr.blacklisted:
+                self.blacklisted.append(attr)
+            elif not attr.was_build():
+                self.failed.append(attr)
+            elif attr.is_test():
+                self.tests.append(attr)
+            else:
+                self.built.append(attr)
 
     def serialize(self) -> dict[str, list[str]]:
         return {

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -270,19 +270,18 @@ class SystemReport:
         self.built: list[Attr] = []
 
         for attr in attrs:
-            match attr:
-                case _ if attr.broken:
-                    self.broken.append(attr)
-                case _ if attr.blacklisted:
-                    self.blacklisted.append(attr)
-                case _ if not attr.exists:
-                    self.non_existent.append(attr)
-                case _ if not attr.was_build():
-                    self.failed.append(attr)
-                case _ if attr.is_test():
-                    self.tests.append(attr)
-                case _:
-                    self.built.append(attr)
+            if not attr.exists:
+                self.non_existent.append(attr)
+            elif attr.broken:
+                self.broken.append(attr)
+            elif attr.blacklisted:
+                self.blacklisted.append(attr)
+            elif not attr.was_build():
+                self.failed.append(attr)
+            elif attr.is_test():
+                self.tests.append(attr)
+            else:
+                self.built.append(attr)
 
     def serialize(self) -> dict[str, list[dict]]:
         return {

--- a/tests/assets/test_pr_github_action_eval/comparison-changed-paths.json
+++ b/tests/assets/test_pr_github_action_eval/comparison-changed-paths.json
@@ -1,8 +1,54 @@
 {
+  "attrdiffByPlatform": {
+    "x86_64-linux": {
+      "added": [],
+      "changed": [
+        "pkg1"
+      ],
+      "removed": [
+        "pkg2"
+      ]
+    },
+    "aarch64-linux": {
+      "added": [],
+      "changed": [
+        "pkg1"
+      ],
+      "removed": [
+        "pkg2"
+      ]
+    },
+    "x86_64-darwin": {
+      "added": [],
+      "changed": [
+        "pkg1"
+      ],
+      "removed": [
+        "pkg2"
+      ]
+    },
+    "aarch64-darwin": {
+      "added": [],
+      "changed": [
+        "pkg1"
+      ],
+      "removed": [
+        "pkg2"
+      ]
+    }
+  },
   "rebuildsByPlatform": {
-    "x86_64-linux": ["pkg1"],
-    "aarch64-linux": ["pkg1"],
-    "x86_64-darwin": ["pkg1"],
-    "aarch64-darwin": ["pkg1"]
+    "x86_64-linux": [
+      "pkg1"
+    ],
+    "aarch64-linux": [
+      "pkg1"
+    ],
+    "x86_64-darwin": [
+      "pkg1"
+    ],
+    "aarch64-darwin": [
+      "pkg1"
+    ]
   }
 }

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -13,7 +13,7 @@ from urllib.error import HTTPError
 import pytest
 
 from nixpkgs_review.cli import main
-from nixpkgs_review.utils import nix_nom_tool
+from nixpkgs_review.utils import current_system, nix_nom_tool
 
 if TYPE_CHECKING:
     from .conftest import Helpers, Nixpkgs
@@ -383,6 +383,90 @@ def test_pr_github_action_eval(
                 ],
             )
             helpers.assert_built(path, "pkg1", "bashInteractive")
+
+
+@patch("nixpkgs_review.http_requests.urlopen")
+def test_pr_github_action_eval_uses_attrdiff_by_platform_removed_attrs(
+    mock_urlopen: MagicMock,
+    helpers: Helpers,
+) -> None:
+    with helpers.nixpkgs() as nixpkgs:
+        base, head, merge = setup_repo(nixpkgs)
+
+        pr = json.loads(
+            helpers.read_asset("test_pr_github_action_eval/github-pull-363128.json")
+        )
+        pr["merge_commit_sha"] = merge
+        pr["base"]["sha"] = base
+        pr["head"]["sha"] = head
+
+        system = current_system()
+        mock_zip = io.BytesIO()
+        with zipfile.ZipFile(mock_zip, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr(
+                "changed-paths.json",
+                json.dumps(
+                    {
+                        "attrdiffByPlatform": {
+                            system: {
+                                "added": [],
+                                "changed": ["pkg1"],
+                                "removed": ["pkg2"],
+                            }
+                        },
+                        "rebuildsByPlatform": {system: ["pkg1"]},
+                    }
+                ),
+            )
+        mock_zip.seek(0)
+
+        additional_mocks = [
+            mock_open(
+                read_data=helpers.read_asset(
+                    "test_pr_github_action_eval/github-workflows-363128.json"
+                ).encode()
+            )(),
+            mock_open(
+                read_data=helpers.read_asset(
+                    "test_pr_github_action_eval/github-artifacts-363128.json"
+                ).encode()
+            )(),
+            mock_open(read_data=mock_zip.getvalue())(),
+        ]
+
+        mock_urlopen.side_effect = [
+            mock_open(read_data=json.dumps(pr).encode())(),
+            mock_open(read_data=create_mock_diff_content().encode())(),
+            *additional_mocks,
+        ]
+
+        hdrs = HTTPMessage()
+        hdrs.add_header("Location", "http://example.com")
+        http_error = HTTPError(
+            url="http://example.com",
+            code=302,
+            msg="Found",
+            hdrs=hdrs,
+            fp=None,
+        )
+
+        with patch(
+            "nixpkgs_review.github.no_redirect_opener.open", side_effect=http_error
+        ):
+            path = main(
+                "nixpkgs-review",
+                [
+                    "pr",
+                    "--remote",
+                    str(nixpkgs.remote),
+                    "--run",
+                    "exit 0",
+                    "363128",
+                ],
+            )
+            helpers.assert_built(path, "pkg1")
+            report = helpers.load_report(path)
+            assert {*report["result"][system]["non-existent"]} == {"pkg2"}
 
 
 @patch("nixpkgs_review.http_requests.urlopen")

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -13,7 +13,7 @@ from urllib.error import HTTPError
 import pytest
 
 from nixpkgs_review.cli import main
-from nixpkgs_review.utils import nix_nom_tool
+from nixpkgs_review.utils import current_system, nix_nom_tool
 
 if TYPE_CHECKING:
     from .conftest import Helpers, Nixpkgs
@@ -383,6 +383,10 @@ def test_pr_github_action_eval(
                 ],
             )
             helpers.assert_built(path, "pkg1", "bashInteractive")
+            # pkg2 is only listed in attrdiffByPlatform.removed
+            report = helpers.load_report(path)
+            non_existent = report["result"][current_system()]["non-existent"]
+            assert [a["name"] for a in non_existent] == ["pkg2"]
 
 
 @patch("nixpkgs_review.http_requests.urlopen")

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -308,6 +308,9 @@ def test_pr_ofborg_eval(mock_urlopen: MagicMock, helpers: Helpers) -> None:
         helpers.assert_built(path, "pkg1")
 
 
+# Without a token nixpkgs-review silently falls back to local evaluation and
+# the artifact code path is never exercised.
+@patch.dict("os.environ", {"GITHUB_TOKEN": "foo"})
 @patch("nixpkgs_review.http_requests.urlopen")
 def test_pr_github_action_eval(
     mock_urlopen: MagicMock,


### PR DESCRIPTION
Read attrdiffByPlatform from comparison artifacts and merge added/removed attrs into the imported per-system package set when that metadata is available.

Classify attrs with exists = false as non-existent before broken so platform-specific removals are reported accurately.

---

Fixes issues like https://github.com/NixOS/nixpkgs/pull/511376, https://github.com/NixOS/nixpkgs/pull/507400, where removed packages show up as "No rebuilds" which is confusing and error-prone.

Instead, it shows:

```txt
--------- Report for 'x86_64-linux' ---------
2 packages present in ofBorgs evaluation, but not found in the checkout:
python313Packages.howdoi python314Packages.howdoi
```

The wording could be improved so that it explicitly distinguishes removed packages from simply missing packages, but that's a secondary thing.

Depends on new attrdiffByPlatform CI artifacts introduced in https://github.com/NixOS/nixpkgs/pull/509519.