### PR TITLE
Post `nixpkgs-merge-bot` as a separate comment

### DIFF
--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -651,9 +651,12 @@ class Review:
             else:
                 self.github_client.approve_pr(
                     pr,
-                    "Approved automatically following the successful run of `nixpkgs-review`."
-                    + ("\n\n@NixOS/nixpkgs-merge-bot merge" if action.merge_pr else ""),
+                    "Approved automatically following the successful run of `nixpkgs-review`.",
                 )
+                if action.merge_pr:
+                    self.github_client.comment_issue(
+                        pr, "@NixOS/nixpkgs-merge-bot merge"
+                    )
 
         if action.print_result:
             print(report.markdown(path, pr))


### PR DESCRIPTION
@NixOS/nixpkgs-merge-bot is only triggered on exact message, messages like "@NixOS/nixpkgs-merge-bot merge :tada:" do not work

See https://github.com/NixOS/nixpkgs/pull/513526#pullrequestreview-4176760802 or https://github.com/NixOS/nixpkgs/pull/503416#issuecomment-4260575002