### PR TITLE
fix: no builds with --additional-packages when pr has no rebuilds

### DIFF
--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -483,9 +483,12 @@ class Review:
         prefixed_additional = _prefix_with_pkgs(
             self.package_filter.additional_packages, self.build_config.pkgs
         )
+        systems_additional: set[str] = (
+            self.systems if len(prefixed_additional) > 0 else set()
+        )
         packages_per_system = {
-            system: prefixed_additional | packages
-            for system, packages in packages_per_system.items()
+            system: prefixed_additional | packages_per_system.get(system, set())
+            for system in packages_per_system.keys() | systems_additional
         }
         return nix_build(
             packages_per_system,


### PR DESCRIPTION
When one or more packages were given through the --additional-packages flag and the PR being reviewed (through `nixpkkgs-review pr`) did not have any rebuild, no builds were triggered instead of simply building the given packages.
This commit changes the logic to ensure the additional packages are always built for the given systems.

Example PR: https://github.com/NixOS/nixpkgs/pull/513548