### PR TITLE
Omit `<details>` if 2 or fewer error logs

### DIFF
--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -106,7 +106,7 @@ def remove_ansi_escape_sequences(text: str) -> str:
 
 
 def html_logs_section(logs_dir: Path, packages: list[Attr], system: str) -> str:
-    res = ""
+    logs = []
     seen_tails = set()
     for pkg in packages:
         if tail := html.escape(
@@ -114,16 +114,14 @@ def html_logs_section(logs_dir: Path, packages: list[Attr], system: str) -> str:
                 get_file_tail(logs_dir / get_log_filename(pkg, system))
             )
         ):
-            if not res:
-                res = "\n---\n"
-                res += f"<details>\n<summary>Error logs: `{system}`</summary>\n"
             if tail in seen_tails:
                 continue
-            res += f"<details>\n<summary>{html.escape(pkg.name)}</summary>\n<pre>{tail}</pre>\n</details>\n"
+            logs.append(f"<details>\n<summary>{html.escape(pkg.name)}</summary>\n<pre>{tail}</pre>\n</details>")
             seen_tails.add(tail)
-    if res:
-        res += "</details>\n"
-    return res
+    if not logs:
+        return ""
+    else:
+        return f"\n---\n<details>\n<summary>Error logs: `{system}`</summary>\n{"\n".join(logs)}\n</details>\n"
 
 
 class LazyDirectory:

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -120,6 +120,8 @@ def html_logs_section(logs_dir: Path, packages: list[Attr], system: str) -> str:
             seen_tails.add(tail)
     if not logs:
         return ""
+    elif len(logs) <= 2:
+        return f"\n---\n{"\n".join(logs)}\n"
     else:
         return f"\n---\n<details>\n<summary>Error logs: `{system}`</summary>\n{"\n".join(logs)}\n</details>\n"
 

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -116,14 +116,15 @@ def html_logs_section(logs_dir: Path, packages: list[Attr], system: str) -> str:
         ):
             if tail in seen_tails:
                 continue
-            logs.append(f"<details>\n<summary>{html.escape(pkg.name)}</summary>\n<pre>{tail}</pre>\n</details>")
+            logs.append(
+                f"<details>\n<summary>{html.escape(pkg.name)}</summary>\n<pre>{tail}</pre>\n</details>"
+            )
             seen_tails.add(tail)
     if not logs:
         return ""
-    elif len(logs) <= 2:
-        return f"\n---\n{"\n".join(logs)}\n"
-    else:
-        return f"\n---\n<details>\n<summary>Error logs: `{system}`</summary>\n{"\n".join(logs)}\n</details>\n"
+    if len(logs) <= 2:
+        return f"\n---\n{'\n'.join(logs)}\n"
+    return f"\n---\n<details>\n<summary>Error logs: `{system}`</summary>\n{'\n'.join(logs)}\n</details>\n"
 
 
 class LazyDirectory:


### PR DESCRIPTION
saves a click for leaf packages, which make up the majority of packages. This takes no/little additional space

tests:

* https://github.com/NixOS/nixpkgs/pull/508740#issuecomment-4411029923
* https://github.com/NixOS/nixpkgs/pull/516867#issuecomment-4412501168
