### PR TITLE
Gracefully handle PR diffs containing invalid UTF-8

### DIFF
--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -323,7 +323,7 @@ class Review:
 
         try:
             with http_requests.urlopen(diff_url) as response:
-                diff_content = response.read().decode("utf-8")
+                diff_content = response.read().decode("utf-8", errors="replace")
             self._display_diff_preview(diff_content)
         except (URLError, OSError):
             pass


### PR DESCRIPTION
PR diffs may contain invalid UTF-8, see e.g. https://github.com/NixOS/nixpkgs/pull/518690.

Without the change in this PR, `nixpkgs-review pr 518690` fails with `UnicodeDecodeError`:

```
Traceback (most recent call last):
  File "/nix/store/29msiv80hyrkhphc8xh0lf14yhayxl1y-nixpkgs-review/bin/.nixpkgs-review-wrapped", line 9, in <module>
    sys.exit(main())
             ~~~~^^
  File "/nix/store/29msiv80hyrkhphc8xh0lf14yhayxl1y-nixpkgs-review/lib/python3.13/site-packages/nixpkgs_review/__init__.py", line 11, in main
    cli.main(Path(sys.argv[0]).name, sys.argv[1:])
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/29msiv80hyrkhphc8xh0lf14yhayxl1y-nixpkgs-review/lib/python3.13/site-packages/nixpkgs_review/cli/__init__.py", line 410, in main
    return cast("str", args.func(args))
                       ~~~~~~~~~^^^^^^
  File "/nix/store/29msiv80hyrkhphc8xh0lf14yhayxl1y-nixpkgs-review/lib/python3.13/site-packages/nixpkgs_review/cli/pr.py", line 141, in pr_command
    (pr, builddir.path, review.build_pr(pr), review.head_commit)
                        ~~~~~~~~~~~~~~~^^^^
  File "/nix/store/29msiv80hyrkhphc8xh0lf14yhayxl1y-nixpkgs-review/lib/python3.13/site-packages/nixpkgs_review/review.py", line 578, in build_pr
    self._display_pr_info(pr, pr_number)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/nix/store/29msiv80hyrkhphc8xh0lf14yhayxl1y-nixpkgs-review/lib/python3.13/site-packages/nixpkgs_review/review.py", line 326, in _display_pr_info
    diff_content = response.read().decode("utf-8")
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb1 in position 1237: invalid start byte
```

With the change in this PR, `nixpkgs-review pr 518690` gracefully handles the invalid start byte in the PR diff by replacing it with U+FFFD, the Unicode replacement character.