### PR TITLE
Add package aliases to JSON report

### DIFF
--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -79,6 +79,9 @@ class Attr:
             with_output(output): path for output, path in (self.outputs or {}).items()
         }
 
+    def serialize(self) -> dict:
+        return {"name": self.name, "aliases": self.aliases}
+
 
 REVIEW_SHELL: Final[str] = str(ROOT.joinpath("nix/review-shell.nix"))
 

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -256,8 +256,8 @@ def write_error_logs(
             fut.result()
 
 
-def _serialize_attrs(attrs: list[Attr]) -> list[str]:
-    return [a.name for a in attrs]
+def _serialize_attrs(attrs: list[Attr]) -> list[dict]:
+    return [a.serialize() for a in attrs]
 
 
 class SystemReport:
@@ -284,7 +284,7 @@ class SystemReport:
                 case _:
                     self.built.append(attr)
 
-    def serialize(self) -> dict[str, list[str]]:
+    def serialize(self) -> dict[str, list[dict]]:
         return {
             "broken": _serialize_attrs(self.broken),
             "non-existent": _serialize_attrs(self.non_existent),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,7 +182,9 @@ class Helpers:
     @staticmethod
     def assert_built(path: str, *pkg_names: str) -> None:
         report = Helpers.load_report(path)
-        assert {*report["result"][current_system()]["built"]} == {*pkg_names}
+        assert {
+            attr["name"] for attr in report["result"][current_system()]["built"]
+        } == {*pkg_names}
 
     @staticmethod
     @contextmanager


### PR DESCRIPTION
Required if you want to rebuild the markdown report from only the json report like we do in nixpkgs-review-gha.