### PR TITLE
Render concatenated multi report.md files correctly

### DIFF
--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -446,6 +446,7 @@ class Report:
             ":white_check_mark:", report.tests, "built", what="test"
         )
         msg += html_pkgs_section(":white_check_mark:", report.built, "built")
+        msg += "\n"  # render concatenated multi report.md files correctly
         return msg
 
     def _append_logs(self, msg: str, root: Path) -> str:


### PR DESCRIPTION
Before            |  After
:-------------------------:|:-------------------------:
<img width="750" height="979" alt="image" src="https://github.com/user-attachments/assets/2398f2cf-b1e9-456b-ab30-6d7f062d5394" /> | <img width="750" height="1068" alt="image" src="https://github.com/user-attachments/assets/edc2c99c-856f-4f14-b8d4-840bd7aae223" />


