### PR TITLE
Add --option NAME VALUE: generic Nix configuration passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,18 @@ As an alternative, one can also specify remote builder as usual in
 `/etc/nix/machines` or via the `nix.buildMachines` nixos options in
 `configuration.nix`. This allows to parallelize builds across multiple machines.
 
+## Setting arbitrary Nix options
+
+Use `--option NAME VALUE` to pass any Nix configuration setting through to the
+nix evaluation, build and shell invocations nixpkgs-review makes, the same way
+`nix --option` works. It can be given multiple times:
+
+```console
+$ nixpkgs-review pr --option cores 4 --option sandbox false 37244
+```
+
+See `man nix.conf` for the full list of available settings.
+
 ## Cross compile, static, cuda
 
 If you want to cross compile you can do that with the `--pkgs=` flag:

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -321,6 +321,18 @@ def common_flags() -> list[CommonFlag]:
             default=None,
             help="Alternative package set to use for building, e.g. pkgsMusl, pkgsStatic, or pkgsCross.aarch64-multiplatform",
         ),
+        CommonFlag(
+            "--option",
+            dest="options",
+            type=str,
+            nargs=2,
+            metavar=("NAME", "VALUE"),
+            action="append",
+            default=[],
+            help="Set a Nix configuration option, e.g. --option cores 4 "
+            "(can be passed multiple times). Passed through to the nix eval, build "
+            "and shell invocations; see `man nix.conf` for available settings",
+        ),
     ]
 
 

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -29,6 +29,7 @@ class BuildConfig:
     num_eval_workers: int = 1
     max_memory_size: int = 4096
     pkgs: str | None = None
+    options: tuple[tuple[str, str], ...] = ()
 
 
 @dataclass
@@ -86,16 +87,22 @@ class Attr:
 REVIEW_SHELL: Final[str] = str(ROOT.joinpath("nix/review-shell.nix"))
 
 
-def _nix_common_flags(allow: AllowedFeatures, nix_path: str) -> list[str]:
+def option_flags(options: tuple[tuple[str, str], ...]) -> list[str]:
+    return [tok for name, value in options for tok in ("--option", name, value)]
+
+
+def nix_common_flags(build_config: BuildConfig) -> list[str]:
+    allow = build_config.allow
     return [
         "--extra-experimental-features",
         "nix-command",
         *([] if allow.url_literals else ["--option", "lint-url-literals", "fatal"]),
         "--nix-path",
-        nix_path,
+        build_config.nix_path,
         "--allow-import-from-derivation"
         if allow.ifd
         else "--no-allow-import-from-derivation",
+        *option_flags(build_config.options),
     ]
 
 
@@ -112,6 +119,7 @@ class ShellConfig:
     run: str | None = None
     sandbox: bool = False
     pkgs: str | None = None
+    options: tuple[tuple[str, str], ...] = ()
 
 
 def nix_shell(
@@ -145,6 +153,7 @@ def nix_shell(
             *shell_file_args,
             "--nix-path",
             config.nix_path,
+            *option_flags(config.options),
             REVIEW_SHELL,
         ]
         if config.run:
@@ -240,6 +249,7 @@ def _nix_shell_sandbox(
         *shell_file_args,
         "--nix-path",
         config.nix_path,
+        *option_flags(config.options),
         REVIEW_SHELL,
     ]
 
@@ -327,7 +337,7 @@ def multi_system_eval(
             "--max-memory-size",
             str(build_config.max_memory_size),
             "--no-instantiate",
-            *_nix_common_flags(build_config.allow, build_config.nix_path),
+            *nix_common_flags(build_config),
             "--expr",
             f"(import {eval_script} {{ attr-json = {attr_json.name}; }})",
             "--apply",
@@ -399,7 +409,7 @@ def nix_build(
         "build",
         "--file",
         REVIEW_SHELL,
-        *_nix_common_flags(build_config.allow, build_config.nix_path),
+        *nix_common_flags(build_config),
         "--no-link",
         "--keep-going",
     ]
@@ -422,8 +432,7 @@ def nix_build(
     _write_review_shell_drv(
         cache_directory=cache_directory,
         shell_file_args=shell_file_args,
-        allow=build_config.allow,
-        nix_path=build_config.nix_path,
+        build_config=build_config,
     )
 
     command += shell_file_args + shlex.split(args)
@@ -469,14 +478,13 @@ def build_shell_file_args(
 def _write_review_shell_drv(
     cache_directory: Path,
     shell_file_args: list[str],
-    allow: AllowedFeatures,
-    nix_path: str,
+    build_config: BuildConfig,
 ) -> None:
     review_drv_link: Path = cache_directory / "review-shell.drv"
 
     cmd: list[str] = [
         "nix-instantiate",
-        *_nix_common_flags(allow, nix_path),
+        *nix_common_flags(build_config),
         *shell_file_args,
         REVIEW_SHELL,
     ]

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -18,7 +18,15 @@ from . import git, http_requests
 from .builddir import Builddir
 from .errors import NixpkgsReviewError
 from .github import GithubClient, GitHubPullRequest
-from .nix import Attr, BuildConfig, ShellConfig, multi_system_eval, nix_build, nix_shell
+from .nix import (
+    Attr,
+    BuildConfig,
+    ShellConfig,
+    multi_system_eval,
+    nix_build,
+    nix_common_flags,
+    nix_shell,
+)
 from .nixpkgs import fetch_refs
 from .report import Report, ReportOptions
 from .utils import (
@@ -416,10 +424,8 @@ class Review:
         print("Local evaluation for computing rebuilds")
 
         base_packages: dict[System, list[Package]] = list_packages(
-            self.builddir.nix_path,
+            self.build_config,
             self.systems,
-            self.build_config.allow,
-            self.build_config.pkgs,
         )
 
         if head_commit is None:
@@ -430,10 +436,8 @@ class Review:
             self.git_merge(head_commit)
 
         merged_packages: dict[System, list[Package]] = list_packages(
-            self.builddir.nix_path,
+            self.build_config,
             self.systems,
-            self.build_config.allow,
-            self.build_config.pkgs,
             check_meta=True,
         )
 
@@ -687,6 +691,7 @@ class Review:
                 run=self.shell_options.run,
                 sandbox=self.shell_options.sandbox,
                 pkgs=self.build_config.pkgs,
+                options=self.build_config.options,
             )
             nix_shell(report.built_packages(), shell_config)
 
@@ -766,30 +771,23 @@ def parse_packages_xml(stdout: IO[str]) -> list[Package]:
 
 def _list_packages_system(
     system: System,
-    nix_path: str,
-    allow: AllowedFeatures,
-    pkgs: str | None = None,
+    build_config: BuildConfig,
     *,
     check_meta: bool = False,
 ) -> list[Package]:
     cmd = [
         "nix-env",
-        *([] if allow.url_literals else ["--option", "lint-url-literals", "fatal"]),
         "--option",
         "system",
         system,
         "-f",
         "<nixpkgs>",
-        "--nix-path",
-        nix_path,
+        *nix_common_flags(build_config),
         "-qaP",
         "--xml",
         "--out-path",
         "--show-trace",
-        "--allow-import-from-derivation"
-        if allow.ifd
-        else "--no-allow-import-from-derivation",
-        *(["-A", pkgs] if pkgs else []),
+        *(["-A", build_config.pkgs] if build_config.pkgs else []),
     ]
     if check_meta:
         cmd.append("--meta")
@@ -805,24 +803,15 @@ def _list_packages_system(
 
 
 def list_packages(
-    nix_path: str,
+    build_config: BuildConfig,
     systems: set[System],
-    allow: AllowedFeatures,
-    pkgs: str | None = None,
     *,
     check_meta: bool = False,
 ) -> dict[System, list[Package]]:
-    results: dict[System, list[Package]] = {}
-    for system in systems:
-        results[system] = _list_packages_system(
-            system=system,
-            nix_path=nix_path,
-            allow=allow,
-            check_meta=check_meta,
-            pkgs=pkgs,
-        )
-
-    return results
+    return {
+        system: _list_packages_system(system, build_config, check_meta=check_meta)
+        for system in systems
+    }
 
 
 def _collect_package_attrs(
@@ -1018,6 +1007,7 @@ def build_config_from_args(
         num_eval_workers=args.num_eval_workers,
         max_memory_size=args.max_memory_size,
         pkgs=args.pkgs,
+        options=tuple((name, value) for name, value in args.options),
     )
 
 

--- a/tests/test_option_flag.py
+++ b/tests/test_option_flag.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from nixpkgs_review.allow import AllowedFeatures
+from nixpkgs_review.cli import main, parse_args
+from nixpkgs_review.nix import BuildConfig, nix_common_flags, option_flags
+from nixpkgs_review.review import build_config_from_args
+
+if TYPE_CHECKING:
+    import pytest
+
+    from .conftest import Helpers
+
+
+def test_option_flags_expansion() -> None:
+    assert option_flags((("cores", "4"), ("max-jobs", "2"))) == [
+        "--option",
+        "cores",
+        "4",
+        "--option",
+        "max-jobs",
+        "2",
+    ]
+
+
+def test_option_flags_empty() -> None:
+    assert option_flags(()) == []
+
+
+def test_option_flags_preserves_order_on_repeated_name() -> None:
+    # Nix applies --option left-to-right, last occurrence wins; we must not
+    # dedupe or reorder, so the same last-wins behavior falls out naturally.
+    assert option_flags((("cores", "4"), ("cores", "8"))) == [
+        "--option",
+        "cores",
+        "4",
+        "--option",
+        "cores",
+        "8",
+    ]
+
+
+def _build_config(options: tuple[tuple[str, str], ...] = ()) -> BuildConfig:
+    return BuildConfig(
+        allow=AllowedFeatures([]),
+        nix_path="",
+        local_system="x86_64-linux",
+        nixpkgs_config=Path("/dev/null"),
+        options=options,
+    )
+
+
+def test_nix_common_flags_includes_extra_options() -> None:
+    flags = nix_common_flags(_build_config((("cores", "4"),)))
+    assert flags[-3:] == ["--option", "cores", "4"]
+
+
+def test_parse_args_option_flag() -> None:
+    args = parse_args(
+        "nixpkgs-review",
+        ["rev", "HEAD", "--option", "cores", "4", "--option", "max-jobs", "2"],
+    )
+    assert args.options == [["cores", "4"], ["max-jobs", "2"]]
+
+
+def test_parse_args_option_flag_defaults_empty() -> None:
+    args = parse_args("nixpkgs-review", ["rev", "HEAD"])
+    assert args.options == []
+
+
+def test_build_config_from_args_carries_options() -> None:
+    args = parse_args(
+        "nixpkgs-review",
+        ["rev", "HEAD", "--option", "cores", "4", "--option", "max-jobs", "2"],
+    )
+    build_config: BuildConfig = build_config_from_args(
+        args, AllowedFeatures([]), nix_path="", nixpkgs_config=Path("/dev/null")
+    )
+    assert build_config.options == (("cores", "4"), ("max-jobs", "2"))
+
+
+def test_option_flag_end_to_end(
+    helpers: Helpers, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with helpers.nixpkgs() as nixpkgs:
+        nixpkgs.path.joinpath("pkg1.txt").write_text("foo")
+        subprocess.run(["git", "add", "."], check=True)
+        subprocess.run(["git", "commit", "-m", "example-change"], check=True)
+        path = main(
+            "nixpkgs-review",
+            [
+                "rev",
+                "HEAD",
+                "--remote",
+                str(nixpkgs.remote),
+                "--run",
+                "exit 0",
+                "--build-graph",
+                "nix",
+                "--option",
+                "cores",
+                "1",
+            ],
+        )
+        helpers.assert_built(path, "pkg1")
+        assert "--option cores 1" in capsys.readouterr().out


### PR DESCRIPTION
Mirror the `--option` flag of Nix commands, providing a cleaner way to specify remote builders.

Assisted-by: claude-code: claude-opus-4.8, claude-sonnet-4.6