### PR TITLE
Add --tests to build passthru.tests of rebuilt packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,10 @@ attribute set:
 $ nixpkgs-review pr -p nixosTests.ferm 47077
 ```
 
+With `--tests`, the `passthru.tests` of every package that is going to be built
+are built as well and listed under "tests" in the report. They honour
+`--skip-package`/`--skip-package-regex`, e.g. `-P 'netbird\.tests\..*'`.
+
 ## Ignoring ofborg evaluations
 
 By default, nixpkgs-review will use ofborg's evaluation result if available to

--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -340,6 +340,11 @@ def common_flags() -> list[CommonFlag]:
             "and shell invocations; see `man nix.conf` for available settings",
         ),
         CommonFlag(
+            "--tests",
+            action="store_true",
+            help="Also build passthru.tests of the packages selected for building",
+        ),
+        CommonFlag(
             "--store",
             type=str,
             default=None,

--- a/nixpkgs_review/nix.py
+++ b/nixpkgs_review/nix.py
@@ -31,6 +31,7 @@ class BuildConfig:
     options: tuple[tuple[str, str], ...] = ()
     store: str | None = None
     eval_store: str | None = None
+    include_tests: bool = False
 
 
 @dataclass
@@ -71,7 +72,11 @@ class Attr:
         return self._path_verified
 
     def is_test(self) -> bool:
-        return self.name.startswith("nixosTests")
+        return (
+            self.name.startswith("nixosTests")
+            or ".tests." in self.name
+            or self.name.endswith(".tests")
+        )
 
     def outputs_with_name(self) -> dict[str, Path]:
         def with_output(output: str) -> str:
@@ -311,7 +316,10 @@ def multi_system_eval(
             *([] if instantiate else ["--no-instantiate"]),
             *nix_common_flags(build_config),
             "--expr",
-            f"(import {eval_script} {{ attr-json = {attr_json.name}; }})",
+            (
+                f"(import {eval_script} {{ attr-json = {attr_json.name}; "
+                f"include-tests = {str(build_config.include_tests).lower()}; }})"
+            ),
             "--apply",
             "d: { inherit (d) exists broken; }",
         ]
@@ -353,20 +361,12 @@ def multi_system_eval(
 
 
 def nix_build(
-    attr_names_per_system: dict[System, set[str]],
+    attrs_per_system: dict[System, list[Attr]],
     args: str,
     cache_directory: Path,
     build_config: BuildConfig,
     build_graph: str,
-) -> dict[System, list[Attr]]:
-    if not attr_names_per_system:
-        info("Nothing to be built.")
-        return {}
-
-    attrs_per_system: dict[System, list[Attr]] = multi_system_eval(
-        attr_names_per_system, build_config, instantiate=True
-    )
-
+) -> None:
     installables = [
         f"{attr.drv_path}^*"
         for attrs in attrs_per_system.values()
@@ -374,7 +374,7 @@ def nix_build(
         if attr.drv_path and not (attr.broken or attr.blacklisted)
     ]
     if not installables:
-        return attrs_per_system
+        return
 
     # Lets users re-run the exact build without re-evaluating:
     #   nix build --stdin < derivations
@@ -394,4 +394,3 @@ def nix_build(
         *shlex.split(args),
     ]
     sh(command, stdin="\n".join(installables))
-    return attrs_per_system

--- a/nixpkgs_review/nix/evalAttrs.nix
+++ b/nixpkgs_review/nix/evalAttrs.nix
@@ -1,4 +1,7 @@
-{ attr-json }:
+{
+  attr-json,
+  include-tests ? false,
+}:
 
 with builtins;
 mapAttrs (
@@ -62,7 +65,8 @@ mapAttrs (
         else
           lib.flatten (lib.mapAttrsToList (name': _: getProperties "${name}.${name'}") pkg)
       else
-        [ (pkgOrFake name pkg) ];
+        [ (pkgOrFake name pkg) ]
+        ++ lib.optionals (include-tests && pkg ? tests) (getProperties "${name}.tests");
   in
   listToAttrs (concatMap getProperties attrs) // { recurseForDerivations = true; }
 ) (fromJSON (readFile attr-json))

--- a/nixpkgs_review/report.py
+++ b/nixpkgs_review/report.py
@@ -323,6 +323,7 @@ class ReportOptions:
     show_logs: bool = False
     max_workers: int | None = 1
     pkgs: str | None = None
+    tests: bool = False
 
 
 class Report:
@@ -342,6 +343,7 @@ class Report:
         self.checkout = options.checkout
         self.package_filter = package_filter
         self.pkgs = options.pkgs
+        self.tests = options.tests
         self.included_prs = options.included_prs
 
         self.extra_nixpkgs_config = (
@@ -408,6 +410,8 @@ class Report:
             cmd += f" --include-pr {included_pr}"
         if self.pkgs:
             cmd += f" --pkgs={self.pkgs}"
+        if self.tests:
+            cmd += " --tests"
 
         options = {
             "package": self.package_filter.only_packages,

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -517,13 +517,28 @@ class Review:
             system: prefixed_additional | packages_per_system.get(system, set())
             for system in packages_per_system.keys() | systems_additional
         }
-        return nix_build(
-            packages_per_system,
+        if not packages_per_system:
+            info("Nothing to be built.")
+            return {}
+        attrs_per_system = multi_system_eval(
+            packages_per_system, self.build_config, instantiate=True
+        )
+        # --tests expands attrs during eval, after the name based filters ran.
+        for system, attrs in attrs_per_system.items():
+            keep = _apply_package_filters(
+                {a.name for a in attrs},
+                self.package_filter.skip_packages,
+                self.package_filter.skip_packages_regex,
+            )
+            attrs_per_system[system] = [a for a in attrs if a.name in keep]
+        nix_build(
+            attrs_per_system,
             args,
             self.builddir.path,
             self.build_config,
             self.shell_options.build_graph,
         )
+        return attrs_per_system
 
     def _fetch_packages_from_github_eval(
         self, pr: GitHubPullRequest
@@ -676,6 +691,7 @@ class Review:
                 show_logs=self.review_config.show_logs,
                 max_workers=min(32, os.cpu_count() or 1),
                 pkgs=self.build_config.pkgs,
+                tests=self.build_config.include_tests,
             ),
         )
         report.print_console(path, pr)
@@ -859,7 +875,7 @@ def _join_packages_for_system(
     changed_attrs: dict[Path, Attr],
     specified_attrs: dict[Path, Attr],
 ) -> set[str]:
-    # ofborg does not include tests and manual evaluation is too expensive
+    # the GitHub eval does not include tests, so do not treat them as nonexistent
     tests = {path: attr for path, attr in specified_attrs.items() if attr.is_test()}
 
     nonexistent = specified_attrs.keys() - changed_attrs.keys() - tests.keys()
@@ -1029,6 +1045,7 @@ def build_config_from_args(
         options=tuple((name, value) for name, value in args.options),
         store=args.store,
         eval_store=args.eval_store,
+        include_tests=args.tests,
     )
 
 

--- a/tests/assets/nixpkgs/default.nix
+++ b/tests/assets/nixpkgs/default.nix
@@ -32,6 +32,11 @@ lib.genAttrs' (lib.range 1 (config.pkgCount or 1)) (
     buildCommand = ''
       cat ${./pkg1.txt} > $out
     '';
+  } // {
+    tests = lib.genAttrs [ "simple" "slow" ] (t: mkDerivation {
+      name = "pkg${toString i}-test-${t}";
+      buildCommand = "cat ${./pkg1.txt} > $out";
+    });
   })) // {
   inherit lib bashInteractive stdenv;
   pkgsAlt = lib.genAttrs' (lib.range 1 (config.pkgCount or 1)) (

--- a/tests/test_rev.py
+++ b/tests/test_rev.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from nixpkgs_review.cli import main
+from nixpkgs_review.utils import current_system
 
 if TYPE_CHECKING:
     from .conftest import Helpers
@@ -24,6 +26,34 @@ def test_rev_command(helpers: Helpers) -> None:
             ["rev", "HEAD", "--remote", str(nixpkgs.remote), "--run", "exit 0"],
         )
         helpers.assert_built(path, "pkg1")
+
+
+def test_rev_command_with_tests(helpers: Helpers) -> None:
+    with helpers.nixpkgs() as nixpkgs:
+        nixpkgs.path.joinpath("pkg1.txt").write_text("foo")
+        subprocess.run(["git", "add", "."], check=True)
+        subprocess.run(["git", "commit", "-m", "example-change"], check=True)
+        path = main(
+            "nixpkgs-review",
+            [
+                "rev",
+                "HEAD",
+                "--remote",
+                str(nixpkgs.remote),
+                "--run",
+                "exit 0",
+                "--build-graph",
+                "nix",
+                "--tests",
+                "--skip-package-regex",
+                r".*\.tests\.slow",
+            ],
+        )
+        helpers.assert_built(path, "pkg1")
+        report = helpers.load_report(path)
+        tests = report["result"][current_system()]["tests"]
+        assert [a["name"] for a in tests] == ["pkg1.tests.simple"]
+        assert (Path(path) / "report.md").read_text().count(" --tests") == 1
 
 
 def test_rev_command_without_nom(helpers: Helpers) -> None:


### PR DESCRIPTION
Reviewers routinely want to run a package's passthru.tests but had to
list them by hand with -p. With --tests, evalAttrs.nix expands every
selected package that has a `tests` attribute through the existing
recursive getProperties, so single-drv, attrset and nested test sets
all work and end up in the "tests" section of the report.

Because that expansion happens during evaluation, the skip filters are
re-applied to the evaluated attr names. Review.build() now runs
multi_system_eval itself and hands the Attr lists to nix_build().

Based on #397 by Fabian Möller.

Closes #77

Co-authored-by: Fabian Möller <fabianm88@gmail.com>
