### PR TITLE
Local eval: list packages with nix-eval-jobs instead of nix-env -qaP

### DIFF
--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -312,14 +312,16 @@ def common_flags() -> list[CommonFlag]:
         CommonFlag(
             "--num-eval-workers",
             type=int,
-            default=1,
-            help="Number of parallel `nix-eval-jobs` workers to run simultaneously (warning, can imply heavy RAM usage)",
+            default=None,
+            help="Number of parallel `nix-eval-jobs` workers. Defaults to as many as fit into "
+            "75%% of the available memory at --max-memory-size each, capped at the CPU count",
         ),
         CommonFlag(
             "--max-memory-size",
             type=int,
-            default=4096,
-            help="Maximum `nix-eval-jobs` per worker memory size in megabyte (warning, workers can shortly exceed the limit)",
+            default=None,
+            help="Memory in MiB after which a `nix-eval-jobs` worker is restarted (workers can briefly exceed it). "
+            "Defaults to 75%% of the available memory split across the workers, clamped to 2048..4096",
         ),
         CommonFlag(
             "--pkgs",

--- a/nixpkgs_review/nix/listPackages.nix
+++ b/nixpkgs_review/nix/listPackages.nix
@@ -1,0 +1,27 @@
+# Enumerate all packages of <nixpkgs> for the given systems, for nix-eval-jobs.
+# The first attribute path component is the system so several systems share
+# one pool of eval workers.
+{
+  systems,
+  # e.g. "pkgsCross.aarch64-multiplatform" or null
+  pkgs ? null,
+}:
+let
+  forSystem =
+    system:
+    let
+      nixpkgs = import <nixpkgs> {
+        inherit system;
+        config = import (builtins.getEnv "NIXPKGS_CONFIG");
+      };
+      inherit (nixpkgs) lib;
+      root = if pkgs == null then nixpkgs else lib.attrByPath (lib.splitString "." pkgs) { } nixpkgs;
+    in
+    lib.recurseIntoAttrs root;
+in
+builtins.listToAttrs (
+  map (system: {
+    name = system;
+    value = forSystem system;
+  }) systems
+)

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import itertools
+import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -10,9 +12,8 @@ import time
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 from urllib.error import URLError
-from xml.etree import ElementTree as ET
 
 from . import git, http_requests
 from .builddir import Builddir
@@ -30,9 +31,11 @@ from .nix import (
 from .nixpkgs import fetch_refs
 from .report import Report, ReportOptions
 from .utils import (
+    ROOT,
     PackageFilter,
     System,
     current_system,
+    default_eval_resources,
     die,
     info,
     system_order_key,
@@ -120,8 +123,6 @@ class Package:
     version: str
     attr_path: str
     store_path: str | None
-    homepage: str | None
-    description: str | None
     position: str | None
     old_pkg: Package | None = field(default=None, init=False)
 
@@ -751,91 +752,15 @@ class Review:
         )
 
 
-def _extract_meta_value(elem: ET.Element) -> str:
-    if elem.attrib["type"] == "strings":
-        return ", ".join(e.attrib["value"] for e in elem)
-    return elem.attrib["value"]
+LIST_PACKAGES_NIX: Final[str] = str(ROOT.joinpath("nix/listPackages.nix"))
 
 
-def parse_packages_xml(stdout: IO[str]) -> list[Package]:
-    packages: list[Package] = []
-    current_pkg: Package | None = None
-
-    context = ET.iterparse(stdout, events=("start", "end"))  # noqa: S314
-    for event, elem in context:
-        if elem.tag == "item" and event == "start":
-            attrs = elem.attrib
-            current_pkg = Package(
-                pname=attrs["pname"],
-                version=attrs["version"],
-                attr_path=attrs["attrPath"],
-                store_path=None,
-                homepage=None,
-                description=None,
-                position=None,
-            )
-        elif (
-            elem.tag == "item"
-            and event == "end"
-            and current_pkg
-            and current_pkg.store_path
-        ):
-            packages.append(current_pkg)
-        elif (
-            elem.tag == "output"
-            and event == "start"
-            and elem.attrib["name"] == "out"
-            and current_pkg
-        ):
-            current_pkg.store_path = elem.attrib["path"]
-        elif elem.tag == "meta" and event == "end" and current_pkg:
-            name = elem.attrib["name"]
-            match name:
-                case "homepage":
-                    current_pkg.homepage = _extract_meta_value(elem)
-                case "description":
-                    current_pkg.description = _extract_meta_value(elem)
-                case "position":
-                    current_pkg.position = _extract_meta_value(elem)
-
-        # delete element/attribute connections to free up memory, but don't clear
-        # meta `string`s before they are processed
-        if event == "end" and elem.tag != "string":
-            elem.clear()
-    return packages
-
-
-def _list_packages_system(
-    system: System,
-    build_config: BuildConfig,
-    *,
-    check_meta: bool = False,
-) -> list[Package]:
-    cmd = [
-        "nix-env",
-        "--option",
-        "system",
-        system,
-        "-f",
-        "<nixpkgs>",
-        *nix_common_flags(build_config),
-        "-qaP",
-        "--xml",
-        "--out-path",
-        "--show-trace",
-        *(["-A", build_config.pkgs] if build_config.pkgs else []),
-    ]
-    if check_meta:
-        cmd.append("--meta")
-    info("$ " + " ".join(cmd))
-    with tempfile.NamedTemporaryFile(mode="w") as tmp:
-        res = subprocess.run(cmd, stdout=tmp, check=False)
-        if res.returncode != 0:
-            msg = f"Failed to list packages: nix-env failed with exit code {res.returncode}"
-            raise NixpkgsReviewError(msg)
-        tmp.flush()
-        with Path(tmp.name).open() as f:
-            return parse_packages_xml(f)
+def _parse_drv_name(name: str) -> tuple[str, str]:
+    """builtins.parseDrvName: version starts at the first dash not followed by a letter."""
+    for i, c in enumerate(name):
+        if c == "-" and i + 1 < len(name) and not name[i + 1].isalpha():
+            return name[:i], name[i + 1 :]
+    return name, ""
 
 
 def list_packages(
@@ -844,10 +769,53 @@ def list_packages(
     *,
     check_meta: bool = False,
 ) -> dict[System, list[Package]]:
-    return {
-        system: _list_packages_system(system, build_config, check_meta=check_meta)
-        for system in systems
-    }
+    """List every package of <nixpkgs> for `systems` with nix-eval-jobs.
+
+    Compared to `nix-env -qaP` this bounds memory per worker and evaluates
+    systems and attributes in parallel."""
+    cmd = [
+        "nix-eval-jobs",
+        "--workers",
+        str(build_config.num_eval_workers),
+        "--max-memory-size",
+        str(build_config.max_memory_size),
+        "--no-instantiate",
+        *(["--meta"] if check_meta else []),
+        *nix_common_flags(build_config),
+        "--expr",
+        (
+            f"import {LIST_PACKAGES_NIX} "
+            f"{{ systems = builtins.fromJSON ''{json.dumps(sorted(systems))}''; "
+            f"pkgs = {json.dumps(build_config.pkgs)}; }}"
+        ),
+    ]
+    info("$ " + shlex.join(cmd))
+    packages: dict[System, list[Package]] = {system: [] for system in systems}
+    # keep nix-env -A semantics: attr paths are relative to <nixpkgs>
+    prefix = [build_config.pkgs] if build_config.pkgs else []
+    with subprocess.Popen(cmd, stdout=subprocess.PIPE, text=True) as proc:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            job = json.loads(line)
+            # aliases that throw, meta.broken/unfree refusals, ...: nix-env
+            # skipped those silently as well
+            if "error" in job:
+                continue
+            system, *attr = job["attrPath"]
+            pname, version = _parse_drv_name(job["name"])
+            packages[system].append(
+                Package(
+                    pname=pname,
+                    version=version,
+                    attr_path=".".join(prefix + attr),
+                    store_path=job["outputs"].get("out"),
+                    position=(job.get("meta") or {}).get("position"),
+                )
+            )
+    if proc.returncode != 0:
+        msg = f"Failed to list packages: nix-eval-jobs exited with {proc.returncode}"
+        raise NixpkgsReviewError(msg)
+    return packages
 
 
 def _collect_package_attrs(
@@ -1035,12 +1003,15 @@ def build_config_from_args(
     nixpkgs_config: Path,
 ) -> BuildConfig:
     """Create a BuildConfig from parsed CLI arguments."""
+    workers, max_memory_size = default_eval_resources(
+        args.num_eval_workers, args.max_memory_size
+    )
     return BuildConfig(
         allow=allow,
         nix_path=nix_path,
         nixpkgs_config=nixpkgs_config,
-        num_eval_workers=args.num_eval_workers,
-        max_memory_size=args.max_memory_size,
+        num_eval_workers=workers,
+        max_memory_size=max_memory_size,
         pkgs=args.pkgs,
         options=tuple((name, value) for name, value in args.options),
         store=args.store,

--- a/nixpkgs_review/utils.py
+++ b/nixpkgs_review/utils.py
@@ -134,3 +134,44 @@ def system_order_key(system: System) -> str:
     `aarch64-linux` -> `linuxaarch64`
     """
     return "".join(reversed(system.split("-")))
+
+
+def available_memory_mib() -> int:
+    """MemAvailable on Linux, otherwise half of the physical memory."""
+    try:
+        for line in Path("/proc/meminfo").read_text().splitlines():
+            if line.startswith("MemAvailable:"):
+                return int(line.split()[1]) // 1024
+    except OSError:
+        pass
+    return os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE") // (2 * 1024 * 1024)
+
+
+MIN_WORKER_MIB = 2048
+MAX_WORKER_MIB = 4096
+LONE_WORKER_MIB = 16 * 1024
+MAX_AUTO_WORKERS = 32
+
+
+def default_eval_resources(
+    workers: int | None, max_memory_size: int | None
+) -> tuple[int, int]:
+    """Pick nix-eval-jobs --workers/--max-memory-size for a full nixpkgs listing.
+
+    Measured on nixpkgs: wall time scales ~W^0.74 while each worker (re)start
+    only costs ~26s of re-forcing the shared stdenv core, so within a memory
+    budget more workers beat more memory per worker. Below ~2GiB single large
+    closures (haskellPackages, CUDA) start to thrash, above ~4GiB nothing is
+    gained."""
+    cores = os.cpu_count() or 1
+    budget = int(available_memory_mib() * 0.75)
+    if workers and max_memory_size:
+        return workers, max_memory_size
+    if workers:
+        return workers, max(MIN_WORKER_MIB, min(budget // workers, LONE_WORKER_MIB))
+    if max_memory_size is None:
+        max_memory_size = max(MIN_WORKER_MIB, min(budget // cores, MAX_WORKER_MIB))
+    workers = max(1, min(budget // max_memory_size, cores, MAX_AUTO_WORKERS))
+    if workers == 1:
+        max_memory_size = max(max_memory_size, min(budget, LONE_WORKER_MIB))
+    return workers, max_memory_size

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -554,7 +554,7 @@ def test_pr_checkout_base_with_packages(
 
 
 @patch("nixpkgs_review.http_requests.urlopen")
-@patch("nixpkgs_review.review._list_packages_system")
+@patch("nixpkgs_review.review.list_packages")
 def test_pr_only_packages_does_not_trigger_an_eval(
     mock_eval: MagicMock,
     mock_urlopen: MagicMock,

--- a/tests/test_rev.py
+++ b/tests/test_rev.py
@@ -77,7 +77,7 @@ def test_rev_command_without_nom(helpers: Helpers) -> None:
         helpers.assert_built(path, "pkg1")
 
 
-@patch("nixpkgs_review.review._list_packages_system")
+@patch("nixpkgs_review.review.list_packages")
 def test_rev_only_packages_does_not_trigger_an_eval(
     mock_eval: MagicMock,
     helpers: Helpers,

--- a/tests/test_wip.py
+++ b/tests/test_wip.py
@@ -47,7 +47,7 @@ def test_wip_command_without_nom(
         assert "$ nix build" in captured.out
 
 
-@patch("nixpkgs_review.review._list_packages_system")
+@patch("nixpkgs_review.review.list_packages")
 def test_wip_only_packages_does_not_trigger_an_eval(
     mock_eval: MagicMock,
     helpers: Helpers,


### PR DESCRIPTION
nix-env -qaP over all of nixpkgs is single threaded and peaks at
~16.5 GiB per system, twice per review. On a busy machine two reviews
in parallel were enough to push a 96 GiB box into swap.

nix-eval-jobs --no-instantiate runs in the same read-only mode nix-env
uses for queries, but bounds memory per worker and evaluates attributes
and systems in parallel. Measured on x86_64-linux nixpkgs with --meta:

  nix-env -qaP            306 s  16.5 GiB
  nix-eval-jobs 4 x 2048  272 s   8.4 GiB
  nix-eval-jobs 4 x 4096  227 s  16.7 GiB
  nix-eval-jobs 8 x 2048  185 s  14.9 GiB
  nix-eval-jobs 8 x 4096  159 s  32.2 GiB

All requested systems go into one invocation so they share the worker
pool. Attributes that throw (aliases, meta.broken or unfree refusals)
arrive as error records and are skipped, matching what nix-env did
silently.

--num-eval-workers and --max-memory-size now default from the machine:
75% of MemAvailable is the budget, per-worker memory is budget/cores
clamped to 2..4 GiB, workers are as many as fit (capped at cores and
32). A model fitted to the numbers above (wall ~ W^-0.74, ~26 s per
worker restart) puts this within a few percent of the optimum for
common core/RAM combinations while never exceeding the budget.
