### PR TITLE
list_packages: hide per-attribute eval errors unless the listing fails

### DIFF
--- a/nixpkgs_review/cli/__init__.py
+++ b/nixpkgs_review/cli/__init__.py
@@ -314,14 +314,14 @@ def common_flags() -> list[CommonFlag]:
             type=int,
             default=None,
             help="Number of parallel `nix-eval-jobs` workers. Defaults to as many as fit into "
-            "75%% of the available memory at --max-memory-size each, capped at the CPU count",
+            "60%% of the spare memory at --max-memory-size each, capped at the CPU count",
         ),
         CommonFlag(
             "--max-memory-size",
             type=int,
             default=None,
             help="Memory in MiB after which a `nix-eval-jobs` worker is restarted (workers can briefly exceed it). "
-            "Defaults to 75%% of the available memory split across the workers, clamped to 2048..4096",
+            "Defaults to 60%% of the spare memory split across the workers, clamped to 2048..4096",
         ),
         CommonFlag(
             "--pkgs",

--- a/nixpkgs_review/review.py
+++ b/nixpkgs_review/review.py
@@ -793,7 +793,13 @@ def list_packages(
     packages: dict[System, list[Package]] = {system: [] for system in systems}
     # keep nix-env -A semantics: attr paths are relative to <nixpkgs>
     prefix = [build_config.pkgs] if build_config.pkgs else []
-    with subprocess.Popen(cmd, stdout=subprocess.PIPE, text=True) as proc:
+    # Per-attribute eval errors also end up on stderr, thousands of them for
+    # nixpkgs (aliases, unsupported platforms). Only show them if the whole
+    # listing fails.
+    with (
+        tempfile.TemporaryFile(mode="w+") as stderr,
+        subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=stderr, text=True) as proc,
+    ):
         assert proc.stdout is not None
         for line in proc.stdout:
             job = json.loads(line)
@@ -812,9 +818,13 @@ def list_packages(
                     position=(job.get("meta") or {}).get("position"),
                 )
             )
-    if proc.returncode != 0:
-        msg = f"Failed to list packages: nix-eval-jobs exited with {proc.returncode}"
-        raise NixpkgsReviewError(msg)
+        if proc.wait() != 0:
+            stderr.seek(0)
+            sys.stderr.write(stderr.read())
+            msg = (
+                f"Failed to list packages: nix-eval-jobs exited with {proc.returncode}"
+            )
+            raise NixpkgsReviewError(msg)
     return packages
 
 

--- a/nixpkgs_review/utils.py
+++ b/nixpkgs_review/utils.py
@@ -136,15 +136,41 @@ def system_order_key(system: System) -> str:
     return "".join(reversed(system.split("-")))
 
 
-def available_memory_mib() -> int:
-    """MemAvailable on Linux, otherwise half of the physical memory."""
+def _zfs_arc_reclaimable_mib() -> int:
+    """The ZFS ARC shrinks under pressure but MemAvailable counts it as used."""
+    stats = {"size": 0, "c_min": 0}
+    try:
+        for line in Path("/proc/spl/kstat/zfs/arcstats").read_text().splitlines():
+            match line.split():
+                case [name, _, value] if name in stats:
+                    stats[name] = int(value)
+    except OSError:
+        return 0
+    return max(0, stats["size"] - stats["c_min"]) // (1024 * 1024)
+
+
+def memory_mib() -> tuple[int, int]:
+    """(total, available). Without /proc/meminfo assume half is available."""
+    total = os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE") // (1024 * 1024)
     try:
         for line in Path("/proc/meminfo").read_text().splitlines():
             if line.startswith("MemAvailable:"):
-                return int(line.split()[1]) // 1024
+                available = int(line.split()[1]) // 1024 + _zfs_arc_reclaimable_mib()
+                return total, min(available, total)
     except OSError:
         pass
-    return os.sysconf("SC_PHYS_PAGES") * os.sysconf("SC_PAGE_SIZE") // (2 * 1024 * 1024)
+    return total, total // 2
+
+
+def eval_memory_budget_mib() -> int:
+    """Memory the package listing may use by default.
+
+    MemAvailable is only a snapshot and workers overshoot --max-memory-size
+    until the next attribute boundary, so keep an absolute reserve for the
+    rest of the system and only plan with 60% of what remains."""
+    total, available = memory_mib()
+    reserve = max(2048, total // 10)
+    return max(0, int((available - reserve) * 0.6))
 
 
 MIN_WORKER_MIB = 2048
@@ -163,8 +189,9 @@ def default_eval_resources(
     budget more workers beat more memory per worker. Below ~2GiB single large
     closures (haskellPackages, CUDA) start to thrash, above ~4GiB nothing is
     gained."""
-    cores = os.cpu_count() or 1
-    budget = int(available_memory_mib() * 0.75)
+    # leave a core for the desktop and nix-daemon
+    cores = max(1, (os.cpu_count() or 1) - 1)
+    budget = eval_memory_budget_mib()
     if workers and max_memory_size:
         return workers, max_memory_size
     if workers:


### PR DESCRIPTION
nix-eval-jobs prints every attribute that throws to stderr in addition to the JSON error record. For nixpkgs that is ~19k alias and unsupported-platform messages per listing, which buried the report and slowed the terminal down. Capture stderr and replay it only when nix-eval-jobs itself exits non-zero.